### PR TITLE
feat(api): Agent Creator — flat agent architecture, management tools, persistent routes

### DIFF
--- a/src/agent-manager.ts
+++ b/src/agent-manager.ts
@@ -1000,4 +1000,42 @@ export class AgentManager {
   async registerEntrypointRoute(from: string, toSubject: string): Promise<void> {
     await this.dispatcher.registerEntrypointRoute(from, toSubject);
   }
+
+  /**
+   * Build a Docker image from /data/agents/{agentId}/Dockerfile.
+   * Tags the image as nano-agent-{agentId}:latest.
+   * Returns streamed build logs as a string.
+   */
+  async buildAgentImage(agentId: string): Promise<string> {
+    const agentDir = path.join(DATA_DIR, 'agents', agentId);
+    const dockerfilePath = path.join(agentDir, 'Dockerfile');
+
+    if (!fs.existsSync(dockerfilePath)) {
+      throw new Error(`Dockerfile not found at ${dockerfilePath}`);
+    }
+
+    const tag = `nano-agent-${agentId}:latest`;
+    logger.info({ agentId, tag, agentDir }, 'Building agent Docker image');
+
+    const buildStream = await this.docker.buildImage(
+      { context: agentDir, src: ['Dockerfile'] },
+      { t: tag },
+    ) as NodeJS.ReadableStream;
+
+    return new Promise<string>((resolve, reject) => {
+      const logs: string[] = [];
+      this.docker.modem.followProgress(
+        buildStream,
+        (err: Error | null, output: Array<{ stream?: string; error?: string }>) => {
+          if (err) return reject(err);
+          const errorLine = output.find((o) => o.error);
+          if (errorLine?.error) return reject(new Error(errorLine.error));
+          resolve(logs.join(''));
+        },
+        (event: { stream?: string; error?: string }) => {
+          if (event.stream) logs.push(event.stream);
+        },
+      );
+    });
+  }
 }

--- a/src/api-server.ts
+++ b/src/api-server.ts
@@ -339,6 +339,28 @@ export async function createApiApp(
     });
   }
 
+  // ── Persistent routes helpers ─────────────────────────────────────────────
+  const ROUTES_PATH = path.join(DATA_DIR, 'routes.json');
+
+  interface PersistedRoute {
+    from_topic: string;
+    to_agent_id: string;
+    to_entrypoint: string;
+  }
+
+  function loadRoutes(): PersistedRoute[] {
+    try {
+      return JSON.parse(fs.readFileSync(ROUTES_PATH, 'utf8')) as PersistedRoute[];
+    } catch {
+      return [];
+    }
+  }
+
+  function saveRoutes(routes: PersistedRoute[]): void {
+    fs.mkdirSync(path.dirname(ROUTES_PATH), { recursive: true });
+    fs.writeFileSync(ROUTES_PATH, JSON.stringify(routes, null, 2));
+  }
+
   // Closure for re-use in /internal/reload
   const reloadFeatures = async (): Promise<void> => {
     const config = await configService.load();
@@ -374,78 +396,36 @@ export async function createApiApp(
       }
     }
 
-    // Collect agent IDs managed by teams — root scan must skip these so that
-    // team scan can start them with proper teamId context (for correct container naming).
+    // All agents live in /data/agents/ — flat structure.
+    // /data/teams/{id}/ contains only workflow.json + team.json (no agents subdir).
     const dataTeamsDir = path.join(DATA_DIR, 'teams');
     const dataAgentsDir = path.join(DATA_DIR, 'agents');
-    const teamManagedAgentIds = new Set<string>();
-    if (fs.existsSync(dataTeamsDir)) {
-      for (const teamEntry of fs.readdirSync(dataTeamsDir, { withFileTypes: true })) {
-        if (!teamEntry.isDirectory()) continue;
-        const teamJsonPath = path.join(dataTeamsDir, teamEntry.name, 'team.json');
-        if (!fs.existsSync(teamJsonPath)) continue;
-        try {
-          const team = JSON.parse(fs.readFileSync(teamJsonPath, 'utf8')) as { agents?: string[] };
-          if (Array.isArray(team.agents)) {
-            for (const agentId of team.agents) teamManagedAgentIds.add(agentId);
-          }
-        } catch { /* ignore malformed team.json */ }
-      }
-    }
 
-    // Scan /data/agents/ — skip agents managed by a team (they start in team scan with teamId)
-    if (fs.existsSync(dataAgentsDir)) {
-      const installedAgents = loadAgents(dataAgentsDir);
-      for (const agent of installedAgents) {
-        if (teamManagedAgentIds.has(agent.manifest.id)) continue;
-        if (!manager.getStates().find(s => s.agentId === agent.manifest.id)) {
-          const topics = resolveTopicsForAgent(agent.manifest, agent.binding);
-          await ensureConsumer(nc, 'AGENTS', agent.manifest.id, topics);
-          await manager.startAgent(agent);
-        }
-      }
-    }
-
-    // Scan /data/teams/*/ — expand instances from workflow.json (multi-instance + dispatch support).
-    // Falls back to team.json agents list when no workflow.json instances block is present.
+    // First pass: process team workflows — start agents with their bindings.
+    // Agents referenced by a workflow are started here; the second pass skips already-running ones.
     if (fs.existsSync(dataTeamsDir)) {
       for (const teamEntry of fs.readdirSync(dataTeamsDir, { withFileTypes: true })) {
         if (!teamEntry.isDirectory()) continue;
         const teamDir = path.join(dataTeamsDir, teamEntry.name);
-        const teamAgentsDir = path.join(teamDir, 'agents');
 
-        // Load workflow for this team (workflow.json → team.json fallback)
         const workflow = loadWorkflow(teamDir);
+        if (!workflow) continue;
 
-        // Expand instances: workflow.instances block (if present) or fallback to agents list
-        const instances = workflow
-          ? expandInstances(workflow, teamAgentsDir, dataAgentsDir)
-          : [];
-
-        // If no workflow, fall back to legacy team agent loading with root fallback
-        if (!workflow) {
-          const { loadTeamAgentsWithFallback } = await import('./agent-registry.js');
-          const legacyAgents = loadTeamAgentsWithFallback(teamEntry.name, teamDir, dataAgentsDir);
-          instances.push(...legacyAgents);
-        }
+        const instances = expandInstances(workflow, dataAgentsDir, dataAgentsDir);
 
         for (const agent of instances) {
           const instanceId = getInstanceId(agent);
           const consumerName = agent.consumerName ?? instanceId;
           const existing = manager.getStates().find(s => s.agentId === instanceId);
           if (!existing || existing.status === 'dead') {
-            // Dead agents (max restarts reached) are reset and restarted on explicit reload
-            if (existing?.status === 'dead') {
-              manager.removeFromStates(instanceId);
-            }
+            if (existing?.status === 'dead') manager.removeFromStates(instanceId);
             const topics = resolveTopicsForAgent(agent.manifest, agent.binding, instanceId);
             await ensureConsumer(nc, 'AGENTS', consumerName, topics);
             await manager.startAgent(agent);
           }
         }
 
-        // Register non-broadcast dispatch rules
-        if (workflow?.dispatch) {
+        if (workflow.dispatch) {
           for (const [subject, dispatchConfig] of Object.entries(workflow.dispatch)) {
             if (dispatchConfig.strategy !== 'broadcast') {
               await manager.registerDispatch(subject, dispatchConfig);
@@ -453,8 +433,6 @@ export async function createApiApp(
           }
         }
 
-        // Register entrypoint routes for { from, to } binding inputs
-        // Dispatcher bridges external topic → agent.{instanceId}.{portName}
         for (const agent of instances) {
           const instanceId = getInstanceId(agent);
           for (const input of Object.values(agent.binding?.inputs ?? {})) {
@@ -464,6 +442,23 @@ export async function createApiApp(
           }
         }
       }
+    }
+
+    // Second pass: start any agents in /data/agents/ not yet running (no workflow binding).
+    if (fs.existsSync(dataAgentsDir)) {
+      for (const agent of loadAgents(dataAgentsDir)) {
+        if (!manager.getStates().find(s => s.agentId === agent.manifest.id)) {
+          const topics = resolveTopicsForAgent(agent.manifest, agent.binding);
+          await ensureConsumer(nc, 'AGENTS', agent.manifest.id, topics);
+          await manager.startAgent(agent);
+        }
+      }
+    }
+
+    // Load persistent routes from /data/routes.json
+    for (const route of loadRoutes()) {
+      const toSubject = `agent.${route.to_agent_id}.${route.to_entrypoint}`;
+      await manager.registerEntrypointRoute(route.from_topic, toSubject);
     }
 
     // Load workflow plugins (routes registered by installed teams)
@@ -875,6 +870,137 @@ export async function createApiApp(
       res.json({ ok: true, serverId });
     } catch (err) {
       logger.error({ err }, 'POST /internal/mcp-servers/:serverId/restart error');
+      res.status(500).json({ error: String(err) });
+    }
+  });
+
+  app.post('/internal/agents/:agentId/build', async (req: Request, res: Response) => {
+    try {
+      const { agentId } = req.params;
+      if (!isValidAgentId(agentId)) return res.status(400).json({ error: 'Invalid agent ID' });
+      const logs = await manager.buildAgentImage(agentId);
+      logger.info({ agentId }, 'Agent image built via internal API');
+      res.json({ ok: true, agentId, image: `nano-agent-${agentId}:latest`, logs });
+    } catch (err) {
+      logger.error({ err }, 'POST /internal/agents/:agentId/build error');
+      res.status(500).json({ error: String(err) });
+    }
+  });
+
+  app.get('/internal/agents/:agentId/definition', async (req: Request, res: Response) => {
+    try {
+      const { agentId } = req.params;
+      if (!isValidAgentId(agentId)) return res.status(400).json({ error: 'Invalid agent ID' });
+
+      const agentDir = path.join(DATA_DIR, 'agents', agentId);
+      if (!fs.existsSync(agentDir)) {
+        return res.status(404).json({ error: `Agent "${agentId}" not found in /data/agents/` });
+      }
+
+      const manifestPath = path.join(agentDir, 'manifest.json');
+      const claudeMdPath = path.join(agentDir, 'CLAUDE.md');
+      const dockerfilePath = path.join(agentDir, 'Dockerfile');
+
+      res.json({
+        agent_id: agentId,
+        manifest: fs.existsSync(manifestPath)
+          ? JSON.parse(fs.readFileSync(manifestPath, 'utf8'))
+          : null,
+        claude_md: fs.existsSync(claudeMdPath)
+          ? fs.readFileSync(claudeMdPath, 'utf8')
+          : null,
+        dockerfile: fs.existsSync(dockerfilePath)
+          ? fs.readFileSync(dockerfilePath, 'utf8')
+          : null,
+      });
+    } catch (err) {
+      logger.error({ err }, 'GET /internal/agents/:agentId/definition error');
+      res.status(500).json({ error: String(err) });
+    }
+  });
+
+  app.put('/internal/agents/:agentId/definition', async (req: Request, res: Response) => {
+    try {
+      const { agentId } = req.params;
+      if (!isValidAgentId(agentId)) return res.status(400).json({ error: 'Invalid agent ID' });
+
+      const { manifest, claude_md, dockerfile } = req.body as {
+        manifest?: Record<string, unknown>;
+        claude_md?: string;
+        dockerfile?: string | null;
+      };
+
+      const agentDir = path.join(DATA_DIR, 'agents', agentId);
+      fs.mkdirSync(agentDir, { recursive: true });
+
+      if (manifest !== undefined) {
+        fs.writeFileSync(path.join(agentDir, 'manifest.json'), JSON.stringify(manifest, null, 2));
+      }
+      if (claude_md !== undefined) {
+        fs.writeFileSync(path.join(agentDir, 'CLAUDE.md'), claude_md);
+      }
+      if (dockerfile !== undefined) {
+        if (dockerfile === null) {
+          // Remove Dockerfile if explicitly set to null
+          const p = path.join(agentDir, 'Dockerfile');
+          if (fs.existsSync(p)) fs.unlinkSync(p);
+        } else {
+          fs.writeFileSync(path.join(agentDir, 'Dockerfile'), dockerfile);
+        }
+      }
+
+      logger.info({ agentId }, 'Agent definition saved via internal API');
+      res.json({ ok: true, agentId, path: agentDir });
+    } catch (err) {
+      logger.error({ err }, 'PUT /internal/agents/:agentId/definition error');
+      res.status(500).json({ error: String(err) });
+    }
+  });
+
+  app.get('/internal/routes', (_req: Request, res: Response) => {
+    res.json(loadRoutes());
+  });
+
+  app.post('/internal/routes', async (req: Request, res: Response) => {
+    try {
+      const { from_topic, to_agent_id, to_entrypoint = 'inbox' } = req.body as {
+        from_topic: string;
+        to_agent_id: string;
+        to_entrypoint?: string;
+      };
+
+      if (!/^[a-z0-9._-]+$/.test(from_topic)) return res.status(400).json({ error: 'Invalid from_topic' });
+      if (!isValidAgentId(to_agent_id)) return res.status(400).json({ error: 'Invalid to_agent_id' });
+      if (!/^[a-z0-9_-]+$/.test(to_entrypoint)) return res.status(400).json({ error: 'Invalid to_entrypoint' });
+
+      const routes = loadRoutes().filter(r => r.from_topic !== from_topic); // replace if exists
+      routes.push({ from_topic, to_agent_id, to_entrypoint });
+      saveRoutes(routes);
+
+      const toSubject = `agent.${to_agent_id}.${to_entrypoint}`;
+      await manager.registerEntrypointRoute(from_topic, toSubject);
+
+      logger.info({ from_topic, to_agent_id, to_entrypoint }, 'Persistent route created');
+      res.json({ ok: true, from_topic, to_agent_id, to_entrypoint });
+    } catch (err) {
+      logger.error({ err }, 'POST /internal/routes error');
+      res.status(500).json({ error: String(err) });
+    }
+  });
+
+  app.delete('/internal/routes/:fromTopic', (req: Request, res: Response) => {
+    try {
+      const fromTopic = decodeURIComponent(req.params.fromTopic);
+      const routes = loadRoutes();
+      const filtered = routes.filter(r => r.from_topic !== fromTopic);
+      if (filtered.length === routes.length) {
+        return res.status(404).json({ error: `Route "${fromTopic}" not found` });
+      }
+      saveRoutes(filtered);
+      logger.info({ fromTopic }, 'Persistent route deleted (takes effect after reload)');
+      res.json({ ok: true, from_topic: fromTopic, note: 'Route removed; active subscription ends on next reload' });
+    } catch (err) {
+      logger.error({ err }, 'DELETE /internal/routes/:fromTopic error');
       res.status(500).json({ error: String(err) });
     }
   });

--- a/src/mcp/management-server.ts
+++ b/src/mcp/management-server.ts
@@ -1,18 +1,25 @@
 /**
- * Management MCP Server — system control + hub catalog browsing
+ * Management MCP Server — system control + hub catalog browsing + agent authoring
  *
  * Runs as a child process inside the settings agent container (stdio transport).
  * Communicates with the control plane via internal HTTP API.
  *
  * Tools:
- *   get_system_status     — running agents + MCP servers + setup mode
- *   start_agent           — start a stopped/dead agent
- *   stop_agent            — stop a running agent
- *   restart_mcp_server    — restart an MCP server (picks up updated secrets)
- *   fetch_hub             — git clone/pull hub catalog to /tmp/hub
- *   list_hub_teams        — list teams available in hub
- *   get_hub_team          — team details: agents, required secrets, description
- *   install_team          — install team from hub + trigger reload
+ *   get_system_status      — running agents + MCP servers + setup mode
+ *   start_agent            — start a stopped/dead agent
+ *   stop_agent             — stop a running agent
+ *   restart_mcp_server     — restart an MCP server (picks up updated secrets)
+ *   fetch_hub              — git clone/pull hub catalog to /tmp/hub
+ *   list_hub_teams         — list teams available in hub
+ *   get_hub_team           — team details: agents, required secrets, description
+ *   install_team           — install team from hub + trigger reload
+ *   install_agent          — install standalone agent from hub + trigger reload
+ *   get_agent_definition   — read manifest, CLAUDE.md, Dockerfile for an agent in /data/agents/
+ *   save_agent_definition  — write/update manifest, CLAUDE.md, Dockerfile for an agent
+ *   build_agent_image      — build Docker image from agent's Dockerfile
+ *   list_routes            — list persistent topic→agent routes from /data/routes.json
+ *   create_route           — add a persistent route: topic → agent entrypoint
+ *   delete_route           — remove a persistent route by from_topic
  */
 
 import { execFileSync } from 'child_process';
@@ -229,6 +236,87 @@ server.setRequestHandler(ListToolsRequestSchema, () => ({
         },
       },
     },
+    {
+      name: 'install_agent',
+      description: 'Install a standalone agent from hub catalog into /data/agents/, triggers reload.',
+      inputSchema: {
+        type: 'object',
+        required: ['agent_id'],
+        properties: {
+          agent_id: { type: 'string', description: 'Agent ID from hub/agents/, e.g. "agent-creator"' },
+        },
+      },
+    },
+    {
+      name: 'get_agent_definition',
+      description: 'Read the definition files (manifest.json, CLAUDE.md, Dockerfile) of an agent in /data/agents/.',
+      inputSchema: {
+        type: 'object',
+        required: ['agent_id'],
+        properties: {
+          agent_id: { type: 'string', description: 'Agent ID' },
+        },
+      },
+    },
+    {
+      name: 'save_agent_definition',
+      description: 'Create or update an agent definition in /data/agents/{id}/. Pass only the fields you want to write/overwrite. Set dockerfile to null to remove it.',
+      inputSchema: {
+        type: 'object',
+        required: ['agent_id'],
+        properties: {
+          agent_id: { type: 'string', description: 'Agent ID (kebab-case, e.g. "my-agent")' },
+          manifest: {
+            type: 'object',
+            description: 'Agent manifest (id, name, model, session_type, entrypoints, …)',
+          },
+          claude_md: { type: 'string', description: 'CLAUDE.md system prompt content' },
+          dockerfile: {
+            description: 'Dockerfile content as string, or null to remove it',
+          },
+        },
+      },
+    },
+    {
+      name: 'build_agent_image',
+      description: 'Build a Docker image from /data/agents/{id}/Dockerfile. Tags as nano-agent-{id}:latest.',
+      inputSchema: {
+        type: 'object',
+        required: ['agent_id'],
+        properties: {
+          agent_id: { type: 'string', description: 'Agent ID' },
+        },
+      },
+    },
+    {
+      name: 'list_routes',
+      description: 'List all persistent topic→agent routes defined in /data/routes.json.',
+      inputSchema: { type: 'object', properties: {} },
+    },
+    {
+      name: 'create_route',
+      description: 'Create a persistent route: messages published to from_topic are forwarded to the agent\'s entrypoint. Stored in /data/routes.json, activated immediately.',
+      inputSchema: {
+        type: 'object',
+        required: ['from_topic', 'to_agent_id'],
+        properties: {
+          from_topic: { type: 'string', description: 'NATS topic to listen on, e.g. "topic.github.pr.finding"' },
+          to_agent_id: { type: 'string', description: 'Target agent ID, e.g. "product-owner"' },
+          to_entrypoint: { type: 'string', description: 'Target entrypoint: "inbox" (default) or "event"' },
+        },
+      },
+    },
+    {
+      name: 'delete_route',
+      description: 'Remove a persistent route by its from_topic.',
+      inputSchema: {
+        type: 'object',
+        required: ['from_topic'],
+        properties: {
+          from_topic: { type: 'string', description: 'The from_topic of the route to remove' },
+        },
+      },
+    },
   ],
 }));
 
@@ -377,10 +465,29 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         };
       }
 
-      // Copy team files to /data/teams/{teamId}
-      const destDir = path.join(DATA_DIR, 'teams', teamId);
-      fs.mkdirSync(destDir, { recursive: true });
-      execFileSync('cp', ['-r', `${teamDir}/.`, destDir], { timeout: 10_000 });
+      // Copy team descriptor files (team.json, workflow.json, setup.json, src/, config/, shared/, …)
+      // to /data/teams/{teamId}/ — but NOT the agents/ subdir (agents go to /data/agents/).
+      const teamDestDir = path.join(DATA_DIR, 'teams', teamId);
+      fs.mkdirSync(teamDestDir, { recursive: true });
+      for (const entry of fs.readdirSync(teamDir, { withFileTypes: true })) {
+        if (entry.name === 'agents') continue; // agents go to /data/agents/ instead
+        const src = path.join(teamDir, entry.name);
+        const dest = path.join(teamDestDir, entry.name);
+        execFileSync('cp', ['-r', src, dest], { timeout: 10_000 });
+      }
+
+      // Copy each agent to /data/agents/{agentId}/
+      const hubAgentsDir = path.join(teamDir, 'agents');
+      const installedAgents: string[] = [];
+      if (fs.existsSync(hubAgentsDir)) {
+        for (const entry of fs.readdirSync(hubAgentsDir, { withFileTypes: true })) {
+          if (!entry.isDirectory()) continue;
+          const agentDest = path.join(DATA_DIR, 'agents', entry.name);
+          fs.mkdirSync(agentDest, { recursive: true });
+          execFileSync('cp', ['-r', `${path.join(hubAgentsDir, entry.name)}/.`, agentDest], { timeout: 10_000 });
+          installedAgents.push(entry.name);
+        }
+      }
 
       // Update config.json
       const config = loadConfig();
@@ -400,8 +507,92 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       await callInternal('POST', '/internal/reload');
 
       return {
-        content: [{ type: 'text', text: JSON.stringify({ ok: true, team_id: teamId, installed_to: destDir }) }],
+        content: [{
+          type: 'text',
+          text: JSON.stringify({ ok: true, team_id: teamId, team_dir: teamDestDir, agents: installedAgents }),
+        }],
       };
+    }
+
+    case 'install_agent': {
+      const agentId = a.agent_id as string;
+      if (!/^[a-z0-9_-]+$/.test(agentId)) {
+        return { content: [{ type: 'text', text: 'Invalid agent_id format.' }], isError: true };
+      }
+      const srcDir = path.join(HUB_DIR, 'agents', agentId);
+      if (!fs.existsSync(srcDir)) {
+        return {
+          content: [{ type: 'text', text: `Agent "${agentId}" not found in hub. Call fetch_hub first.` }],
+          isError: true,
+        };
+      }
+      const destDir = path.join(DATA_DIR, 'agents', agentId);
+      fs.mkdirSync(destDir, { recursive: true });
+      execFileSync('cp', ['-r', `${srcDir}/.`, destDir], { timeout: 10_000 });
+      await callInternal('POST', '/internal/reload');
+      return {
+        content: [{ type: 'text', text: JSON.stringify({ ok: true, agent_id: agentId, installed_to: destDir }) }],
+      };
+    }
+
+    case 'get_agent_definition': {
+      const agentId = a.agent_id as string;
+      if (!/^[a-z0-9_-]+$/.test(agentId)) {
+        return { content: [{ type: 'text', text: 'Invalid agent_id format.' }], isError: true };
+      }
+      const result = await callInternal('GET', `/internal/agents/${agentId}/definition`);
+      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+    }
+
+    case 'save_agent_definition': {
+      const agentId = a.agent_id as string;
+      if (!/^[a-z0-9_-]+$/.test(agentId)) {
+        return { content: [{ type: 'text', text: 'Invalid agent_id format.' }], isError: true };
+      }
+      const body: Record<string, unknown> = {};
+      if (a.manifest !== undefined) body.manifest = a.manifest;
+      if (a.claude_md !== undefined) body.claude_md = a.claude_md;
+      if (a.dockerfile !== undefined) body.dockerfile = a.dockerfile;
+      const result = await callInternal('PUT', `/internal/agents/${agentId}/definition`, body);
+      return { content: [{ type: 'text', text: JSON.stringify(result) }] };
+    }
+
+
+    case 'build_agent_image': {
+      const agentId = a.agent_id as string;
+      if (!/^[a-z0-9_-]+$/.test(agentId)) {
+        return { content: [{ type: 'text', text: 'Invalid agent_id format.' }], isError: true };
+      }
+      const result = await callInternal('POST', `/internal/agents/${agentId}/build`);
+      return { content: [{ type: 'text', text: JSON.stringify(result) }] };
+    }
+
+    case 'list_routes': {
+      const result = await callInternal('GET', '/internal/routes');
+      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+    }
+
+    case 'create_route': {
+      const fromTopic = a.from_topic as string;
+      const toAgentId = a.to_agent_id as string;
+      const toEntrypoint = (a.to_entrypoint as string | undefined) ?? 'inbox';
+      if (!/^[a-z0-9._-]+$/.test(fromTopic)) {
+        return { content: [{ type: 'text', text: 'Invalid from_topic format.' }], isError: true };
+      }
+      if (!/^[a-z0-9_-]+$/.test(toAgentId)) {
+        return { content: [{ type: 'text', text: 'Invalid to_agent_id format.' }], isError: true };
+      }
+      const result = await callInternal('POST', '/internal/routes', { from_topic: fromTopic, to_agent_id: toAgentId, to_entrypoint: toEntrypoint });
+      return { content: [{ type: 'text', text: JSON.stringify(result) }] };
+    }
+
+    case 'delete_route': {
+      const fromTopic = a.from_topic as string;
+      if (!/^[a-z0-9._-]+$/.test(fromTopic)) {
+        return { content: [{ type: 'text', text: 'Invalid from_topic format.' }], isError: true };
+      }
+      const result = await callInternal('DELETE', `/internal/routes/${encodeURIComponent(fromTopic)}`);
+      return { content: [{ type: 'text', text: JSON.stringify(result) }] };
     }
 
     default:

--- a/src/workflow-registry.ts
+++ b/src/workflow-registry.ts
@@ -177,11 +177,10 @@ export function expandInstances(
 
 function resolveAgentDir(
   manifestId: string,
-  teamAgentsDir: string,
+  _teamAgentsDir: string,
   rootAgentsDir?: string,
 ): string | null {
-  const teamDir = path.join(teamAgentsDir, manifestId);
-  if (fs.existsSync(path.join(teamDir, 'manifest.json'))) return teamDir;
+  // All agents live in /data/agents/ (rootAgentsDir) — no per-team agents subdir.
   if (rootAgentsDir) {
     const rootDir = path.join(rootAgentsDir, manifestId);
     if (fs.existsSync(path.join(rootDir, 'manifest.json'))) return rootDir;


### PR DESCRIPTION
## Summary

- **Flat agent architecture**: all agents live in `/data/agents/{id}/` — no more per-team `agents/` subdirectories. `/data/teams/{id}/` contains only `workflow.json` + `team.json`.
- **Management MCP tools** for Agent Creator and Settings Agent: `get_agent_definition`, `save_agent_definition`, `build_agent_image`, `install_agent`, `list_routes`, `create_route`, `delete_route`
- **Internal API endpoints**: `GET/PUT /internal/agents/:id/definition`, `POST /internal/agents/:id/build`, `GET/POST /internal/routes`, `DELETE /internal/routes/:fromTopic`
- **Persistent routes** (`/data/routes.json`): cross-agent topic routing, activated immediately and re-registered on reload
- **`buildAgentImage()`** on AgentManager: builds Docker image via Dockerode streaming build API

## Architecture change

Before:
```
/data/teams/github-team/agents/pr-reviewer/  ← agent lived here
/data/agents/                                ← only standalone agents
```

After:
```
/data/agents/pr-reviewer/                    ← all agents here
/data/teams/github-team/                     ← workflow.json + team.json only
```

`install_team` now copies agents to `/data/agents/` and team descriptors to `/data/teams/`.

## Enables use case

1. **Agent Creator** (hub PR) modifies `pr-reviewer` to publish findings to `topic.github.pr.finding`
2. **Settings Agent** calls `create_route("topic.github.pr.finding", "product-owner", "inbox")` to wire them together

## Related

- hub PR: nano-agent-team/hub feat/agent-creator
- Closes #20

## Test plan

- [ ] `install_team` installs agents to `/data/agents/` and team descriptor to `/data/teams/`
- [ ] Agents from team workflows start correctly with bindings resolved from `/data/agents/`
- [ ] Standalone agents in `/data/agents/` start without bindings
- [ ] `save_agent_definition` + `build_agent_image` + `start_agent` creates and runs a new agent
- [ ] `create_route` wires two agents via NATS topic; messages are forwarded correctly
- [ ] Routes persist across restarts (loaded from `/data/routes.json` in `reloadFeatures`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)