### PR TITLE
bug(agent-runner): stale session_id after container restart causes agent to hang on first message

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -510,7 +510,13 @@ async function main(): Promise<void> {
       }
       if (firstMessageOfLifecycle) {
         firstMessageOfLifecycle = false;
-        log.info({ agentId: AGENT_ID }, 'First message completed — subsequent messages will resume session');
+        if (!sessionId) {
+          // First message failed without producing a session — clear stale file
+          try { fs.unlinkSync(path.join('/workspace/sessions', 'session_id')); } catch { /* ignore */ }
+          log.warn({ agentId: AGENT_ID }, 'First message failed without session — cleared stale session file');
+        } else {
+          log.info({ agentId: AGENT_ID }, 'First message completed — subsequent messages will resume session');
+        }
       }
       currentSessionId = undefined;
 


### PR DESCRIPTION
Closes #37

Autonomously developed by self-dev pipeline (PM → Architect → Developer → Reviewer → Committer).

**Changes:**  1 file changed, 11 insertions(+), 2 deletions(-)

Generated with nano-agent-team self-dev pipeline