### PR TITLE
feat: guidance, trust & learning loop

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -640,6 +640,7 @@ async function main(): Promise<void> {
             // Output validation: track publish_signal calls
             // MCP tools have namespaced names: mcp__soul__publish_signal
             const bareName = event.toolName.replace(/^mcp__soul__/, '');
+            log.info({ agentId: AGENT_ID, toolName: event.toolName, bareName }, 'Tool call detected');
             if (bareName === 'publish_signal') {
               publishSignalCalled = true;
             }
@@ -738,7 +739,7 @@ async function main(): Promise<void> {
       if (!outputValidationEnabled || publishSignalCalled) {
         msg.ack();
       } else {
-        log.warn({ agentId: AGENT_ID }, 'No publish_signal called — retrying once');
+        log.warn({ agentId: AGENT_ID, resultPreview: result.substring(0, 500) }, 'No publish_signal called — retrying once');
         const retryWorking = setInterval(() => { try { msg.working(); } catch {} }, 30_000);
         try {
           for await (const ev of provider.run({
@@ -757,6 +758,20 @@ async function main(): Promise<void> {
         msg.ack();
         if (!publishSignalCalled) {
           log.error({ agentId: AGENT_ID }, 'Agent swallowed message — no publish_signal after retry');
+          // Fallback: publish pipeline.task.failed so dispatcher knows the task didn't complete properly
+          try {
+            const failPayload = JSON.stringify({
+              agentId: AGENT_ID,
+              reason: 'Agent completed work but did not call publish_signal — likely missing mcp_permissions.soul',
+              resultPreview: result.substring(0, 300),
+              subject,
+              ts: Date.now(),
+            });
+            nc.publish('pipeline.task.failed', codec.encode(failPayload));
+            log.info({ agentId: AGENT_ID }, 'Published pipeline.task.failed fallback signal');
+          } catch (fallbackErr) {
+            log.error({ err: fallbackErr }, 'Failed to publish fallback signal');
+          }
         }
       }
 

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -240,6 +240,45 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
+  // ── Reflect phase helpers ──────────────────────────────────────────────────
+  function buildReflectPrompt(taskSummary: string, taskResult: string, rejectionReason: string, prevLearnings: string): string {
+    return [
+      '## Reflect Phase',
+      '',
+      'You just completed a task. Review your work and call `journal_reflect`.',
+      '',
+      '### Task',
+      taskSummary,
+      '',
+      '### Result',
+      taskResult,
+      rejectionReason ? `**Rejection reason:** ${rejectionReason}` : '',
+      '',
+      '### Your Previous Learnings (last 10)',
+      prevLearnings || '_No previous learnings._',
+    ].join('\n');
+  }
+
+  function readLastLearnings(agentId: string, obsidianBase: string, maxEntries: number = 10): string {
+    const learningsPath = path.join(obsidianBase, 'Consciousness', 'agents', agentId, 'learnings.md');
+    try {
+      const content = fs.readFileSync(learningsPath, 'utf-8');
+      const entries = content.split(/^---$/m).filter(e => e.trim());
+      return entries.slice(-maxEntries).join('\n---\n');
+    } catch {
+      return '';
+    }
+  }
+
+  function readAgentProfile(agentId: string, obsidianBase: string): string {
+    const profilePath = path.join(obsidianBase, 'Consciousness', 'agents', agentId, 'profile.md');
+    try {
+      return fs.readFileSync(profilePath, 'utf-8');
+    } catch {
+      return '';
+    }
+  }
+
   // ── Ephemeral mode: process a single task from env var, then exit ─────────
   const ephemeralTaskB64 = process.env.EPHEMERAL_TASK_MESSAGE;
   if (ephemeralTaskB64) {
@@ -315,24 +354,78 @@ async function main(): Promise<void> {
       log.warn({ err }, 'Failed to write ephemeral result file');
     }
 
-    // ── After-work hook: set ticket to done (deterministic handoff) ──────
+    // ── Reflect phase: self-reflect before setting ticket to done ───────────
     // Only on success — failed agents leave ticket in_progress for orphan detection
     const ephemeralTicketId = process.env.EPHEMERAL_TICKET_ID;
     if (!errorSubtype && ephemeralTicketId) {
+      const taskSummary = (payload as Record<string, unknown>).text as string
+        ?? JSON.stringify(payloadForPrompt, null, 2).slice(0, 2000);
+      const prevLearnings = readLastLearnings(AGENT_ID, '/obsidian');
+      const profile = readAgentProfile(AGENT_ID, '/obsidian');
+      const reflectContext = profile
+        ? `${prevLearnings}\n\n### Your Learning Profile\n${profile}`
+        : prevLearnings;
+      const reflectPrompt = buildReflectPrompt(taskSummary, 'done', '', reflectContext);
+
+      log.info({ agentId: AGENT_ID, ticketId: ephemeralTicketId }, 'Starting reflect phase');
+
+      let reflectDone = false;
       try {
-        const apiUrl = MCP_GATEWAY_URL.replace('/mcp', '') || 'http://host.docker.internal:3001';
-        const resp = await fetch(`${apiUrl}/api/tickets/${encodeURIComponent(ephemeralTicketId)}`, {
-          method: 'PATCH',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ status: 'done', expected_status: 'in_progress', changed_by: AGENT_ID }),
+        const reflectTimeout = setTimeout(() => {
+          if (!reflectDone) {
+            log.warn({ agentId: AGENT_ID }, 'Reflect phase timed out (60s) — falling back to direct ticket_update');
+            const apiUrl = MCP_GATEWAY_URL.replace('/mcp', '') || 'http://host.docker.internal:3001';
+            fetch(`${apiUrl}/api/tickets/${encodeURIComponent(ephemeralTicketId)}`, {
+              method: 'PATCH',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ status: 'done', expected_status: 'in_progress', changed_by: AGENT_ID }),
+            }).catch(() => {});
+          }
+        }, 60_000);
+
+        const reflectRun = provider.run({
+          model: MODEL,
+          modelExplicit: MODEL_EXPLICIT,
+          cwd: '/workspace',
+          prompt: reflectPrompt,
+          maxTurns: 3,
+          systemPrompt: (systemPrompt || '') + '\n\nYou are in REFLECT PHASE. Call journal_reflect with your self-assessment. Do not do any other work.',
+          ...(AGENT_ALLOWED_TOOLS.length > 0 ? { allowedTools: AGENT_ALLOWED_TOOLS } : {}),
+          mcpServers: allMcpServers,
         });
-        if (resp.ok) {
-          log.info({ ticketId: ephemeralTicketId }, 'After-work: ticket set to done');
-        } else {
-          log.warn({ ticketId: ephemeralTicketId, status: resp.status }, 'After-work: failed to set done');
+
+        for await (const event of reflectRun) {
+          if (event.type === 'result') {
+            reflectDone = true;
+            log.info({ agentId: AGENT_ID }, 'Reflect phase completed');
+          }
         }
+
+        clearTimeout(reflectTimeout);
       } catch (err) {
-        log.warn({ err, ticketId: ephemeralTicketId }, 'After-work: error (non-fatal)');
+        log.warn({ err, agentId: AGENT_ID }, 'Reflect phase failed — falling back to direct ticket_update');
+      }
+
+      // Always set ticket to done after reflect (reflect only writes to Obsidian)
+      if (!reflectDone) {
+        // reflect timed out — ticket already set to done by timeout handler above
+      } else {
+        // reflect completed — now set ticket to done
+        try {
+          const apiUrl = MCP_GATEWAY_URL.replace('/mcp', '') || 'http://host.docker.internal:3001';
+          const resp = await fetch(`${apiUrl}/api/tickets/${encodeURIComponent(ephemeralTicketId)}`, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ status: 'done', expected_status: 'in_progress', changed_by: AGENT_ID }),
+          });
+          if (resp.ok) {
+            log.info({ ticketId: ephemeralTicketId }, 'After-work: ticket set to done');
+          } else {
+            log.warn({ ticketId: ephemeralTicketId, status: resp.status }, 'After-work: failed to set done');
+          }
+        } catch (err) {
+          log.warn({ err, ticketId: ephemeralTicketId }, 'After-work: error (non-fatal)');
+        }
       }
     }
 

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -406,26 +406,25 @@ async function main(): Promise<void> {
         log.warn({ err, agentId: AGENT_ID }, 'Reflect phase failed — falling back to direct ticket_update');
       }
 
-      // Always set ticket to done after reflect (reflect only writes to Obsidian)
-      if (!reflectDone) {
-        // reflect timed out — ticket already set to done by timeout handler above
-      } else {
-        // reflect completed — now set ticket to done
-        try {
-          const apiUrl = MCP_GATEWAY_URL.replace('/mcp', '') || 'http://host.docker.internal:3001';
-          const resp = await fetch(`${apiUrl}/api/tickets/${encodeURIComponent(ephemeralTicketId)}`, {
-            method: 'PATCH',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ status: 'done', expected_status: 'in_progress', changed_by: AGENT_ID }),
-          });
-          if (resp.ok) {
-            log.info({ ticketId: ephemeralTicketId }, 'After-work: ticket set to done');
-          } else {
-            log.warn({ ticketId: ephemeralTicketId, status: resp.status }, 'After-work: failed to set done');
-          }
-        } catch (err) {
-          log.warn({ err, ticketId: ephemeralTicketId }, 'After-work: error (non-fatal)');
+      // Always set ticket to done — reflect only writes to Obsidian, ticket_update is our responsibility
+      // Three cases: reflect succeeded, reflect threw, or timeout already fired
+      try {
+        const apiUrl = MCP_GATEWAY_URL.replace('/mcp', '') || 'http://host.docker.internal:3001';
+        const resp = await fetch(`${apiUrl}/api/tickets/${encodeURIComponent(ephemeralTicketId)}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ status: 'done', expected_status: 'in_progress', changed_by: AGENT_ID }),
+        });
+        if (resp.ok) {
+          log.info({ ticketId: ephemeralTicketId, reflectDone }, 'After-work: ticket set to done');
+        } else if (resp.status === 409) {
+          // 409 = expected_status mismatch — timeout handler already set it to done
+          log.info({ ticketId: ephemeralTicketId }, 'After-work: ticket already done (timeout handler)');
+        } else {
+          log.warn({ ticketId: ephemeralTicketId, status: resp.status }, 'After-work: failed to set done');
         }
+      } catch (err) {
+        log.warn({ err, ticketId: ephemeralTicketId }, 'After-work: error (non-fatal)');
       }
     }
 

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -351,77 +351,79 @@ async function main(): Promise<void> {
       log.warn({ err }, 'Failed to write ephemeral result file');
     }
 
-    // ── Reflect phase: self-reflect before setting ticket to done ───────────
-    // Only on success — failed agents leave ticket in_progress for orphan detection
+    // ── Reflect phase: self-reflect after task completion ────────────────────
     const ephemeralTicketId = process.env.EPHEMERAL_TICKET_ID;
-    if (!errorSubtype && ephemeralTicketId) {
+    if (ephemeralTicketId) {
       const taskSummary = (payload as Record<string, unknown>).text as string
         ?? JSON.stringify(payloadForPrompt, null, 2).slice(0, 2000);
+      const taskResult = errorSubtype ? 'rejected' : 'done';
       const prevLearnings = readLastLearnings(AGENT_ID, '/obsidian');
       const profile = readAgentProfile(AGENT_ID, '/obsidian');
       const reflectContext = profile
         ? `${prevLearnings}\n\n### Your Learning Profile\n${profile}`
         : prevLearnings;
-      const reflectPrompt = buildReflectPrompt(taskSummary, 'done', '', reflectContext);
+      const reflectPrompt = buildReflectPrompt(taskSummary, taskResult, errorSubtype ?? '', reflectContext);
 
-      log.info({ agentId: AGENT_ID, ticketId: ephemeralTicketId }, 'Starting reflect phase');
+      log.info({ agentId: AGENT_ID, ticketId: ephemeralTicketId, taskResult }, 'Starting reflect phase');
+
+      // Ensure journal_reflect is available for the reflect phase
+      const reflectAllowedTools = AGENT_ALLOWED_TOOLS.length > 0
+        ? [...new Set([...AGENT_ALLOWED_TOOLS, 'mcp__soul__journal_reflect'])]
+        : undefined;
 
       let reflectDone = false;
       try {
-        const reflectTimeout = setTimeout(() => {
-          if (!reflectDone) {
-            log.warn({ agentId: AGENT_ID }, 'Reflect phase timed out (60s) — falling back to direct ticket_update');
-            const apiUrl = MCP_GATEWAY_URL.replace('/mcp', '') || 'http://host.docker.internal:3001';
-            fetch(`${apiUrl}/api/tickets/${encodeURIComponent(ephemeralTicketId)}`, {
-              method: 'PATCH',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ status: 'done', expected_status: 'in_progress', changed_by: AGENT_ID }),
-            }).catch(() => {});
-          }
-        }, 60_000);
+        const timeoutPromise = new Promise<void>((resolve) => setTimeout(resolve, 60_000));
 
-        const reflectRun = provider.run({
-          model: MODEL,
-          modelExplicit: MODEL_EXPLICIT,
-          cwd: '/workspace',
-          prompt: reflectPrompt,
-          maxTurns: 3,
-          systemPrompt: (systemPrompt || '') + '\n\nYou are in REFLECT PHASE. Call journal_reflect with your self-assessment. Do not do any other work.',
-          ...(AGENT_ALLOWED_TOOLS.length > 0 ? { allowedTools: AGENT_ALLOWED_TOOLS } : {}),
-          mcpServers: allMcpServers,
-        });
+        const reflectPromiseRun = (async () => {
+          const reflectRun = provider.run({
+            model: MODEL,
+            modelExplicit: MODEL_EXPLICIT,
+            cwd: '/workspace',
+            prompt: reflectPrompt,
+            maxTurns: 3,
+            systemPrompt: (systemPrompt || '') + '\n\nYou are in REFLECT PHASE. Call journal_reflect with your self-assessment. Do not do any other work.',
+            ...(reflectAllowedTools ? { allowedTools: reflectAllowedTools } : {}),
+            mcpServers: allMcpServers,
+          });
 
-        for await (const event of reflectRun) {
-          if (event.type === 'result') {
-            reflectDone = true;
-            log.info({ agentId: AGENT_ID }, 'Reflect phase completed');
+          for await (const event of reflectRun) {
+            if (event.type === 'result') {
+              reflectDone = true;
+              log.info({ agentId: AGENT_ID }, 'Reflect phase completed');
+            }
           }
+        })();
+
+        await Promise.race([reflectPromiseRun, timeoutPromise]);
+
+        if (!reflectDone) {
+          log.warn({ agentId: AGENT_ID }, 'Reflect phase timed out (60s)');
         }
-
-        clearTimeout(reflectTimeout);
       } catch (err) {
-        log.warn({ err, agentId: AGENT_ID }, 'Reflect phase failed — falling back to direct ticket_update');
+        log.warn({ err, agentId: AGENT_ID }, 'Reflect phase failed');
       }
 
-      // Always set ticket to done — reflect only writes to Obsidian, ticket_update is our responsibility
-      // Three cases: reflect succeeded, reflect threw, or timeout already fired
-      try {
-        const apiUrl = MCP_GATEWAY_URL.replace('/mcp', '') || 'http://host.docker.internal:3001';
-        const resp = await fetch(`${apiUrl}/api/tickets/${encodeURIComponent(ephemeralTicketId)}`, {
-          method: 'PATCH',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ status: 'done', expected_status: 'in_progress', changed_by: AGENT_ID }),
-        });
-        if (resp.ok) {
-          log.info({ ticketId: ephemeralTicketId, reflectDone }, 'After-work: ticket set to done');
-        } else if (resp.status === 409) {
-          // 409 = expected_status mismatch — timeout handler already set it to done
-          log.info({ ticketId: ephemeralTicketId }, 'After-work: ticket already done (timeout handler)');
-        } else {
-          log.warn({ ticketId: ephemeralTicketId, status: resp.status }, 'After-work: failed to set done');
+      // Only set ticket to done on SUCCESS — failed agents leave ticket in_progress for orphan detection
+      if (!errorSubtype) {
+        try {
+          const apiUrl = MCP_GATEWAY_URL.replace('/mcp', '') || 'http://host.docker.internal:3001';
+          const resp = await fetch(`${apiUrl}/api/tickets/${encodeURIComponent(ephemeralTicketId)}`, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ status: 'done', expected_status: 'in_progress', changed_by: AGENT_ID }),
+          });
+          if (resp.ok) {
+            log.info({ ticketId: ephemeralTicketId, reflectDone }, 'After-work: ticket set to done');
+          } else if (resp.status === 409) {
+            // 409 = expected_status mismatch — concurrent update already set status
+            log.info({ ticketId: ephemeralTicketId }, 'After-work: ticket already updated (409 conflict)');
+          } else {
+            log.warn({ ticketId: ephemeralTicketId, status: resp.status }, 'After-work: failed to set done');
+          }
+        } catch (err) {
+          log.warn({ err, ticketId: ephemeralTicketId }, 'After-work: error (non-fatal)');
         }
-      } catch (err) {
-        log.warn({ err, ticketId: ephemeralTicketId }, 'After-work: error (non-fatal)');
       }
     }
 

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -225,9 +225,12 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  // Write system prompt via provider
-  const systemPromptContent = AGENT_SYSTEM_PROMPT || (fs.existsSync(CLAUDE_MD_PATH) ? fs.readFileSync(CLAUDE_MD_PATH, 'utf8') : '');
-  let systemPrompt = systemPromptContent || `# ${AGENT_ID}\n\nYou are ${AGENT_ID}, a helpful AI agent.\n`;
+  // Build system prompt: ARCHITECTURE.md (shared) + CLAUDE.md (agent-specific)
+  const ARCHITECTURE_PATH = '/workspace/ARCHITECTURE.md';
+  const architectureContent = fs.existsSync(ARCHITECTURE_PATH) ? fs.readFileSync(ARCHITECTURE_PATH, 'utf8') : '';
+  const agentContent = AGENT_SYSTEM_PROMPT || (fs.existsSync(CLAUDE_MD_PATH) ? fs.readFileSync(CLAUDE_MD_PATH, 'utf8') : '');
+  const combined = [architectureContent, agentContent].filter(Boolean).join('\n\n---\n\n');
+  let systemPrompt = combined || `# ${AGENT_ID}\n\nYou are ${AGENT_ID}, a helpful AI agent.\n`;
 
   try {
     provider.writeSystemPrompt('/workspace', systemPrompt);

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -225,12 +225,9 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  // Build system prompt: ARCHITECTURE.md (shared) + CLAUDE.md (agent-specific)
-  const ARCHITECTURE_PATH = '/workspace/ARCHITECTURE.md';
-  const architectureContent = fs.existsSync(ARCHITECTURE_PATH) ? fs.readFileSync(ARCHITECTURE_PATH, 'utf8') : '';
-  const agentContent = AGENT_SYSTEM_PROMPT || (fs.existsSync(CLAUDE_MD_PATH) ? fs.readFileSync(CLAUDE_MD_PATH, 'utf8') : '');
-  const combined = [architectureContent, agentContent].filter(Boolean).join('\n\n---\n\n');
-  let systemPrompt = combined || `# ${AGENT_ID}\n\nYou are ${AGENT_ID}, a helpful AI agent.\n`;
+  // System prompt assembled by agent-manager: constitution → shards → CLAUDE.md → team config → vault
+  const systemPromptContent = AGENT_SYSTEM_PROMPT || (fs.existsSync(CLAUDE_MD_PATH) ? fs.readFileSync(CLAUDE_MD_PATH, 'utf8') : '');
+  let systemPrompt = systemPromptContent || `# ${AGENT_ID}\n\nYou are ${AGENT_ID}, a helpful AI agent.\n`;
 
   try {
     provider.writeSystemPrompt('/workspace', systemPrompt);

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -576,6 +576,7 @@ async function main(): Promise<void> {
 
       // ── Output validation: reset per-message tracking ─────────────────────
       let publishSignalCalled = false;
+      let lastThinkingEmit = 0;
 
       // ── Provider invocation ───────────────────────────────────────────────
       const existingSessionId = firstMessageOfLifecycle ? undefined : loadSessionId();
@@ -628,6 +629,18 @@ async function main(): Promise<void> {
             if (streamSubject) {
               nc.publish(streamSubject, codec.encode(JSON.stringify({ type: 'chunk', text: event.text })));
             }
+            // Debounced thinking activity for per-agent SSE stream
+            if (Date.now() - lastThinkingEmit > 5000) {
+              lastThinkingEmit = Date.now();
+              try {
+                nc.publish(`activity.${AGENT_ID}`, codec.encode(JSON.stringify({
+                  type: 'thinking',
+                  summary: 'Thinking...',
+                  preview: event.text.substring(0, 100),
+                  timestamp: Date.now(),
+                })));
+              } catch { /* ignore */ }
+            }
           } else if (event.type === 'tool_call') {
             currentTask = baseTask ? `${baseTask} → ${toolActivity(event.toolName)}` : toolActivity(event.toolName);
             publishHeartbeat();
@@ -644,6 +657,15 @@ async function main(): Promise<void> {
             if (bareName === 'publish_signal') {
               publishSignalCalled = true;
             }
+            // Publish activity event for per-agent SSE stream
+            try {
+              nc.publish(`activity.${AGENT_ID}`, codec.encode(JSON.stringify({
+                type: 'tool_call',
+                summary: toolActivity(event.toolName),
+                toolName: event.toolName,
+                timestamp: Date.now(),
+              })));
+            } catch { /* ignore activity publish failure */ }
           } else if (event.type === 'result') {
             result = event.result;
             errorSubtype = event.errorSubtype;

--- a/container/agent-runner/src/providers/claude.ts
+++ b/container/agent-runner/src/providers/claude.ts
@@ -108,10 +108,21 @@ export class ClaudeProvider implements Provider {
           }
         }
 
-        // Record tool calls
-        if (msg['type'] === 'tool_use_summary') {
-          const toolName = typeof msg['tool_name'] === 'string' ? msg['tool_name'] : 'unknown';
-          yield { type: 'tool_call', toolName };
+        // Extract tool calls from assistant messages
+        // SDK emits tool_use as content blocks within assistant messages (not as separate events)
+        if (msg['type'] === 'assistant') {
+          const message = msg['message'] as Record<string, unknown> | undefined;
+          const content = message?.['content'];
+          if (Array.isArray(content)) {
+            for (const block of content) {
+              if (block && typeof block === 'object' && (block as Record<string, unknown>)['type'] === 'tool_use') {
+                const toolName = typeof (block as Record<string, unknown>)['name'] === 'string'
+                  ? (block as Record<string, unknown>)['name'] as string
+                  : 'unknown';
+                yield { type: 'tool_call', toolName };
+              }
+            }
+          }
         }
 
         // Check for result

--- a/dashboard/src/components/AppSidebar.vue
+++ b/dashboard/src/components/AppSidebar.vue
@@ -38,9 +38,8 @@ const route = useRoute()
 const collapsed = ref(false)
 const connected = ref(true)
 
-// Core nav item
+// Core nav items — Thinking is primary, Settings via plugins
 const coreNavItems = [
-  { path: coreModule.routes[0].path as string, label: coreModule.label, icon: coreModule.icon },
   { path: '/soul', label: soulModule.label, icon: soulModule.icon },
 ]
 

--- a/dashboard/src/modules/core/module.config.ts
+++ b/dashboard/src/modules/core/module.config.ts
@@ -7,7 +7,7 @@ export const module = {
   routes: [
     {
       path: '/',
-      component: () => import('./HomeView.vue'),
+      redirect: '/soul',
     },
   ] as RouteRecordRaw[],
 }

--- a/dashboard/src/modules/soul/AgentDetailPanel.vue
+++ b/dashboard/src/modules/soul/AgentDetailPanel.vue
@@ -1,0 +1,327 @@
+<script setup lang="ts">
+import { ref, watch, onUnmounted, computed } from 'vue';
+import { fetchAgentTopology, connectAgentStream } from './SoulApiClient';
+import type { AgentTopologyNode, AgentActivityEvent } from './SoulApiClient';
+
+const props = defineProps<{
+  agentId: string;
+}>();
+const emit = defineEmits<{
+  close: [];
+}>();
+
+interface ExpandableEvent extends AgentActivityEvent {
+  expanded: boolean;
+}
+
+interface Connection {
+  direction: 'in' | 'out';
+  target: string;
+  port: string;
+}
+
+const agent = ref<AgentTopologyNode | null>(null);
+const connections = ref<Connection[]>([]);
+const activityEvents = ref<ExpandableEvent[]>([]);
+
+let cleanupStream: (() => void) | null = null;
+
+function activityIcon(type: string): string {
+  switch (type) {
+    case 'tool_call': return '🔧';
+    case 'thinking': return '💭';
+    case 'text': return '💬';
+    case 'signal': return '📡';
+    default: return '•';
+  }
+}
+
+function formatTime(ts: number): string {
+  const d = new Date(ts);
+  return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+}
+
+async function loadAgent(id: string) {
+  const topo = await fetchAgentTopology();
+  agent.value = topo.agents.find(a => a.id === id) ?? null;
+
+  const conns: Connection[] = [];
+  for (const edge of topo.edges) {
+    if (edge.from === id) {
+      conns.push({ direction: 'out', target: edge.to, port: edge.port });
+    }
+    if (edge.to === id) {
+      conns.push({ direction: 'in', target: edge.from, port: edge.port });
+    }
+  }
+  connections.value = conns;
+}
+
+function startStream(id: string) {
+  cleanupStream?.();
+  activityEvents.value = [];
+  cleanupStream = connectAgentStream(id, (ev) => {
+    const expandable: ExpandableEvent = { ...ev, expanded: false };
+    const updated = [expandable, ...activityEvents.value];
+    activityEvents.value = updated.slice(0, 50);
+  });
+}
+
+watch(
+  () => props.agentId,
+  (id) => {
+    if (id) {
+      loadAgent(id);
+      startStream(id);
+    }
+  },
+  { immediate: true },
+);
+
+onUnmounted(() => {
+  cleanupStream?.();
+});
+</script>
+
+<template>
+  <Transition name="panel-slide-left">
+    <div class="agent-detail-panel">
+      <!-- Header -->
+      <div class="detail-header">
+        <span class="detail-icon" :title="agent?.description">{{ agent?.icon || '🤖' }}</span>
+        <span class="detail-name" :title="agent?.description">{{ agent?.name || agentId }}</span>
+        <span class="detail-status" :class="agent?.status">{{ agent?.status }}</span>
+        <button class="detail-close" @click="emit('close')">&times;</button>
+      </div>
+
+      <div class="detail-body">
+        <!-- Connections -->
+        <div class="detail-section" v-if="connections.length">
+          <div class="section-title">Connections</div>
+          <div v-for="conn in connections" :key="conn.target + conn.port" class="conn-item">
+            <span class="conn-dir">{{ conn.direction === 'out' ? '→' : '←' }}</span>
+            <span class="conn-agent">{{ conn.target }}</span>
+            <span class="conn-port">{{ conn.port }}</span>
+          </div>
+        </div>
+
+        <!-- Activity Stream -->
+        <div class="detail-section">
+          <div class="section-title">Activity</div>
+          <div class="activity-stream">
+            <div v-for="(ev, i) in activityEvents" :key="i" class="activity-item"
+                 @click="ev.expanded = !ev.expanded">
+              <div class="activity-summary">
+                <span class="activity-icon">{{ activityIcon(ev.type) }}</span>
+                <span class="activity-text">{{ ev.summary }}</span>
+                <span class="activity-time">{{ formatTime(ev.timestamp) }}</span>
+              </div>
+              <div v-if="ev.expanded && ev.detail" class="activity-detail">
+                <pre>{{ ev.detail }}</pre>
+              </div>
+            </div>
+            <div v-if="activityEvents.length === 0" class="empty">No activity yet</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </Transition>
+</template>
+
+<style scoped>
+.agent-detail-panel {
+  position: fixed;
+  left: 0;
+  top: 0;
+  height: 100vh;
+  width: 340px;
+  background: #1e293b;
+  border-right: 1px solid #334155;
+  box-shadow: 4px 0 24px rgba(0, 0, 0, 0.4);
+  z-index: 40;
+  display: flex;
+  flex-direction: column;
+  color: #e2e8f0;
+  font-family: 'Inter', sans-serif;
+}
+
+/* Slide transition */
+.panel-slide-left-enter-active,
+.panel-slide-left-leave-active {
+  transition: transform 0.25s ease;
+}
+.panel-slide-left-enter-from,
+.panel-slide-left-leave-to {
+  transform: translateX(-100%);
+}
+
+/* Header */
+.detail-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 14px 16px;
+  border-bottom: 1px solid #334155;
+  flex-shrink: 0;
+}
+
+.detail-icon {
+  font-size: 20px;
+  cursor: default;
+}
+
+.detail-name {
+  font-weight: 600;
+  font-size: 15px;
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.detail-status {
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 9999px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.detail-status.running {
+  background: rgba(34, 197, 94, 0.15);
+  color: #4ade80;
+}
+.detail-status.dead {
+  background: rgba(239, 68, 68, 0.15);
+  color: #f87171;
+}
+
+.detail-close {
+  background: none;
+  border: none;
+  color: #94a3b8;
+  font-size: 22px;
+  cursor: pointer;
+  padding: 0 4px;
+  line-height: 1;
+}
+.detail-close:hover {
+  color: #e2e8f0;
+}
+
+/* Body */
+.detail-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px 16px;
+}
+
+/* Sections */
+.detail-section {
+  margin-bottom: 20px;
+}
+
+.section-title {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #94a3b8;
+  margin-bottom: 8px;
+}
+
+/* Connections */
+.conn-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 0;
+  font-size: 13px;
+}
+
+.conn-dir {
+  color: #64748b;
+  width: 16px;
+  text-align: center;
+}
+
+.conn-agent {
+  color: #a78bfa;
+}
+
+.conn-port {
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  color: #6b7280;
+  font-size: 11px;
+}
+
+/* Activity Stream */
+.activity-stream {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.activity-item {
+  background: #111827;
+  border-radius: 6px;
+  padding: 8px 10px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+.activity-item:hover {
+  background: #1a2234;
+}
+
+.activity-summary {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+}
+
+.activity-icon {
+  flex-shrink: 0;
+  width: 18px;
+  text-align: center;
+}
+
+.activity-text {
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.activity-time {
+  flex-shrink: 0;
+  font-size: 10px;
+  color: #64748b;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+}
+
+.activity-detail {
+  margin-top: 6px;
+}
+
+.activity-detail pre {
+  background: #0f172a;
+  font-size: 10px;
+  padding: 8px;
+  border-radius: 4px;
+  overflow: auto;
+  max-height: 200px;
+  margin: 0;
+  color: #cbd5e1;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.empty {
+  color: #64748b;
+  font-size: 13px;
+  text-align: center;
+  padding: 16px 0;
+}
+</style>

--- a/dashboard/src/modules/soul/AgentGraphView.vue
+++ b/dashboard/src/modules/soul/AgentGraphView.vue
@@ -2,7 +2,6 @@
   <div ref="containerEl" class="agent-graph-container">
     <svg ref="svgEl" class="agent-graph-svg">
       <defs>
-        <!-- Gradient for nodes -->
         <radialGradient id="node-gradient-active" cx="40%" cy="35%">
           <stop offset="0%" stop-color="#a78bfa" />
           <stop offset="100%" stop-color="#4c1d95" />
@@ -11,7 +10,6 @@
           <stop offset="0%" stop-color="#4b5563" />
           <stop offset="100%" stop-color="#1f2937" />
         </radialGradient>
-        <!-- Glow filter for active nodes -->
         <filter id="agent-glow" x="-50%" y="-50%" width="200%" height="200%">
           <feGaussianBlur stdDeviation="6" result="blur" />
           <feMerge>
@@ -19,7 +17,6 @@
             <feMergeNode in="SourceGraphic" />
           </feMerge>
         </filter>
-        <!-- Arrow marker for edges -->
         <marker id="arrow" viewBox="0 -4 8 8" refX="8" refY="0"
                 markerWidth="6" markerHeight="6" orient="auto">
           <path d="M0,-3L8,0L0,3" fill="#6b7280" opacity="0.6" />
@@ -32,46 +29,42 @@
     <Transition name="panel-slide">
       <div v-if="selectedAgent" class="agent-detail-panel">
         <div class="detail-header">
-          <span class="detail-icon">{{ selectedAgent.icon }}</span>
-          <span class="detail-name">{{ selectedAgent.label }}</span>
-          <span class="detail-status" :class="selectedAgent.active ? 'active' : 'idle'">
-            {{ selectedAgent.active ? 'Active' : 'Idle' }}
+          <span class="detail-name">{{ selectedAgent.name }}</span>
+          <span class="detail-status" :class="selectedAgent.status">
+            {{ selectedAgent.status }}
           </span>
           <button class="detail-close" @click="selectedAgent = null">&times;</button>
         </div>
         <div class="detail-body">
+          <div class="detail-section">
+            <div class="detail-section-title">Description</div>
+            <div class="detail-desc">{{ selectedAgent.description || 'No description' }}</div>
+          </div>
           <div v-if="selectedAgent.currentActivity" class="detail-section">
             <div class="detail-section-title">Currently working on</div>
             <div class="detail-current">
               <div class="detail-current-summary">{{ selectedAgent.currentActivity.summary }}</div>
-              <div v-if="selectedAgent.currentActivity.entityId" class="detail-current-entity">
-                {{ selectedAgent.currentActivity.entityId }}
+            </div>
+          </div>
+          <div v-if="selectedAgent.connections.length" class="detail-section">
+            <div class="detail-section-title">Connections</div>
+            <div class="detail-connections">
+              <div v-for="conn in selectedAgent.connections" :key="conn.target + conn.port" class="detail-conn">
+                <span class="conn-direction">{{ conn.direction === 'out' ? '→' : '←' }}</span>
+                <span class="conn-agent">{{ conn.target }}</span>
+                <span class="conn-port">{{ conn.port }}</span>
+                <span v-if="conn.messageCount" class="conn-count">{{ conn.messageCount }} msgs</span>
               </div>
             </div>
           </div>
-          <div v-else class="detail-section">
-            <div class="detail-section-title">Currently working on</div>
-            <div class="detail-empty">No current activity</div>
-          </div>
-          <div v-if="selectedAgent.journal.length" class="detail-section">
-            <div class="detail-section-title">💭 Thoughts</div>
-            <div class="detail-journal">
-              <div v-for="(entry, idx) in selectedAgent.journal" :key="idx" class="journal-entry">
-                <div class="journal-time">{{ entry.timestamp.split('T')[1] }}</div>
-                <div class="journal-text">{{ entry.text }}</div>
-              </div>
-            </div>
-          </div>
-          <div class="detail-section">
+          <div v-if="selectedAgent.recentEvents.length" class="detail-section">
             <div class="detail-section-title">Recent activity</div>
-            <div v-if="selectedAgent.recentEvents.length" class="detail-events">
+            <div class="detail-events">
               <div v-for="ev in selectedAgent.recentEvents" :key="ev.timestamp + ev.summary" class="detail-event">
                 <div class="detail-event-time">{{ formatTime(ev.timestamp) }}</div>
                 <div class="detail-event-summary">{{ ev.summary }}</div>
-                <div v-if="ev.entityId" class="detail-event-entity">{{ ev.entityId }}</div>
               </div>
             </div>
-            <div v-else class="detail-empty">No recent events</div>
           </div>
         </div>
       </div>
@@ -82,7 +75,8 @@
 <script setup lang="ts">
 import { ref, watch, onMounted, onUnmounted, nextTick } from 'vue';
 import * as d3 from 'd3';
-import type { ActivityEvent } from './SoulApiClient';
+import type { ActivityEvent, AgentTopology, AgentTopologyEdge } from './SoulApiClient';
+import { fetchAgentTopology } from './SoulApiClient';
 
 const props = defineProps<{
   activity: ActivityEvent[];
@@ -92,9 +86,10 @@ const props = defineProps<{
 
 interface AgentNode extends d3.SimulationNodeDatum {
   id: string;
-  label: string;
+  name: string;
   icon: string;
-  known: boolean;
+  description: string;
+  apiStatus: string;
   activityCount: number;
   lastActive: number;
 }
@@ -102,9 +97,10 @@ interface AgentNode extends d3.SimulationNodeDatum {
 interface AgentEdge extends d3.SimulationLinkDatum<AgentNode> {
   sourceId: string;
   targetId: string;
-  count: number;
+  port: string;
+  subject: string;
+  messageCount: number;
   lastTimestamp: number;
-  lastSummary: string;
   lastType: string;
 }
 
@@ -116,48 +112,39 @@ interface Particle {
   birth: number;
 }
 
-// --- Constants ---
-
-const KNOWN_AGENTS: { id: string; label: string; icon: string }[] = [
-  { id: 'chat-agent', label: 'Chat Agent', icon: '\uD83D\uDCAC' },
-  { id: 'consciousness', label: 'Consciousness', icon: '\uD83E\uDDE0' },
-  { id: 'conscience', label: 'Conscience', icon: '\u2696\uFE0F' },
-  { id: 'strategist', label: 'Strategist', icon: '\uD83D\uDCD0' },
-  { id: 'foreman', label: 'Foreman', icon: '\uD83D\uDD27' },
-];
-
-const KNOWN_MAP = new Map(KNOWN_AGENTS.map((a) => [a.id, a]));
-
-const EVENT_COLORS: Record<string, string> = {
-  idea: '#a855f7',      // purple
-  plan: '#3b82f6',      // blue
-  dialogue: '#f97316',  // orange
-  action: '#22c55e',    // green
-  user: '#06b6d4',      // cyan
-  goal: '#eab308',      // yellow
-};
-
-const ACTIVITY_WINDOW_MS = 5 * 60 * 1000; // 5 minutes
-const ACTIVE_THRESHOLD_MS = 30_000;        // 30 seconds
-const PARTICLE_DURATION_MS = 2000;
-
-// --- Detail panel types ---
-
-interface JournalEntry {
-  timestamp: string;
-  agent: string;
-  text: string;
+interface ConnectionInfo {
+  direction: 'in' | 'out';
+  target: string;
+  port: string;
+  messageCount: number;
 }
 
 interface SelectedAgentInfo {
   id: string;
-  label: string;
-  icon: string;
-  active: boolean;
+  name: string;
+  description: string;
+  status: string;
   currentActivity: ActivityEvent | null;
   recentEvents: ActivityEvent[];
-  journal: JournalEntry[];
+  connections: ConnectionInfo[];
 }
+
+// --- Constants ---
+
+const DEFAULT_ICON = '🤖';
+
+const EVENT_COLORS: Record<string, string> = {
+  idea: '#a855f7',
+  plan: '#3b82f6',
+  dialogue: '#f97316',
+  action: '#22c55e',
+  user: '#06b6d4',
+  goal: '#eab308',
+};
+
+const ACTIVE_THRESHOLD_MS = 30_000;
+const PARTICLE_DURATION_MS = 2000;
+const TOPOLOGY_POLL_MS = 10_000;
 
 // --- Refs ---
 
@@ -175,10 +162,10 @@ let particleIdCounter = 0;
 let simulation: d3.Simulation<AgentNode, AgentEdge> | null = null;
 let animationFrame: number | null = null;
 let resizeObserver: ResizeObserver | null = null;
+let topologyInterval: ReturnType<typeof setInterval> | null = null;
 let width = 800;
 let height = 600;
 
-// D3 selections (stored for updates without full re-render)
 let svgSelection: d3.Selection<SVGSVGElement, unknown, null, undefined> | null = null;
 let gSelection: d3.Selection<SVGGElement, unknown, null, undefined> | null = null;
 let edgeGroup: d3.Selection<SVGGElement, unknown, null, undefined> | null = null;
@@ -187,75 +174,45 @@ let particleGroup: d3.Selection<SVGGElement, unknown, null, undefined> | null = 
 
 // --- Helpers ---
 
-function getParticleColor(type: string): string {
-  return EVENT_COLORS[type] || EVENT_COLORS.action;
-}
-
 function edgeKey(from: string, to: string): string {
   return `${from}→${to}`;
 }
 
-function getOrCreateNode(id: string): AgentNode {
-  let node = nodes.find((n) => n.id === id);
-  if (!node) {
-    const known = KNOWN_MAP.get(id);
-    node = {
-      id,
-      label: known?.label || id,
-      icon: known?.icon || '\uD83E\uDD16',
-      known: !!known,
-      activityCount: 0,
-      lastActive: 0,
-    };
-    nodes.push(node);
-  }
-  return node;
-}
-
-function getOrCreateEdge(from: string, to: string): AgentEdge {
-  const key = edgeKey(from, to);
-  let edge = edges.find((e) => e.sourceId === from && e.targetId === to);
-  if (!edge) {
-    const sourceNode = getOrCreateNode(from);
-    const targetNode = getOrCreateNode(to);
-    edge = {
-      source: sourceNode,
-      target: targetNode,
-      sourceId: from,
-      targetId: to,
-      count: 0,
-      lastTimestamp: 0,
-      lastSummary: '',
-      lastType: '',
-    };
-    edges.push(edge);
-  }
-  return edge;
-}
-
 function nodeRadius(node: AgentNode): number {
-  const base = 30;
-  const extra = Math.min(node.activityCount * 0.5, 10);
+  const base = 28;
+  const extra = Math.min(node.activityCount * 0.8, 14);
   return base + extra;
 }
 
 function isActive(node: AgentNode): boolean {
+  return node.apiStatus === 'running' && Date.now() - node.lastActive < ACTIVE_THRESHOLD_MS;
+}
+
+function isBusy(node: AgentNode): boolean {
   return Date.now() - node.lastActive < ACTIVE_THRESHOLD_MS;
 }
 
+function edgeWidth(edge: AgentEdge): number {
+  if (edge.messageCount === 0) return 1;
+  return Math.min(1 + Math.log2(edge.messageCount + 1) * 1.5, 6);
+}
+
 function edgeOpacity(edge: AgentEdge): number {
+  if (edge.messageCount === 0) return 0.15; // static topology edge, no messages yet
   const age = Date.now() - edge.lastTimestamp;
-  if (age < 10_000) return 0.8;
-  if (age < 60_000) return 0.5;
-  if (age < ACTIVITY_WINDOW_MS) return 0.25;
-  return 0.1;
+  if (age < 10_000) return 0.9;
+  if (age < 60_000) return 0.6;
+  if (age < 300_000) return 0.35;
+  return 0.2;
 }
 
-function truncate(text: string, max: number): string {
-  return text.length > max ? text.slice(0, max - 1) + '\u2026' : text;
+function edgeColor(edge: AgentEdge): string {
+  if (edge.messageCount === 0) return '#4b5563';
+  const age = Date.now() - edge.lastTimestamp;
+  if (age < 30_000) return '#a78bfa'; // recent = purple
+  return '#6b7280';
 }
 
-// Compute a curved path between two points
 function edgePath(sx: number, sy: number, tx: number, ty: number): string {
   const dx = tx - sx;
   const dy = ty - sy;
@@ -263,16 +220,13 @@ function edgePath(sx: number, sy: number, tx: number, ty: number): string {
   return `M${sx},${sy}A${dr},${dr} 0 0,1 ${tx},${ty}`;
 }
 
-// Get point along the edge path at parameter t (0..1)
 function pointOnEdge(sx: number, sy: number, tx: number, ty: number, t: number): { x: number; y: number } {
-  // Simple quadratic bezier approximation for the arc
   const dx = tx - sx;
   const dy = ty - sy;
   const dist = Math.sqrt(dx * dx + dy * dy);
-  const offset = dist * 0.15; // perpendicular offset for curve
+  const offset = dist * 0.15;
   const mx = (sx + tx) / 2 - (dy / dist) * offset;
   const my = (sy + ty) / 2 + (dx / dist) * offset;
-  // Quadratic bezier: P = (1-t)^2*S + 2(1-t)t*M + t^2*T
   const u = 1 - t;
   return {
     x: u * u * sx + 2 * u * t * mx + t * t * tx,
@@ -280,60 +234,123 @@ function pointOnEdge(sx: number, sy: number, tx: number, ty: number, t: number):
   };
 }
 
-// --- Build graph from activity events ---
+function getParticleColor(type: string): string {
+  return EVENT_COLORS[type] || EVENT_COLORS.action;
+}
 
-function rebuildGraph() {
-  const now = Date.now();
-  const cutoff = now - ACTIVITY_WINDOW_MS;
+function formatTime(ts: number): string {
+  return new Date(ts).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+}
 
-  // Reset counts
-  nodes.forEach((n) => { n.activityCount = 0; });
+// --- Topology loading ---
 
-  // Always ensure known agents exist
-  KNOWN_AGENTS.forEach((ka) => getOrCreateNode(ka.id));
+async function loadTopology() {
+  const topology = await fetchAgentTopology();
 
-  // Process activity
-  const recentActivity = props.activity.filter((ev) => ev.timestamp > cutoff);
+  // Sync nodes from API
+  const apiIds = new Set(topology.agents.map(a => a.id));
 
-  for (const ev of recentActivity) {
-    // Update source agent
-    const agentNode = getOrCreateNode(ev.agent);
-    agentNode.activityCount++;
-    agentNode.lastActive = Math.max(agentNode.lastActive, ev.timestamp);
-
-    // Update from/to nodes and edges
-    if (ev.from) {
-      const fromNode = getOrCreateNode(ev.from);
-      fromNode.activityCount++;
-      fromNode.lastActive = Math.max(fromNode.lastActive, ev.timestamp);
+  // Add new agents
+  for (const agent of topology.agents) {
+    let node = nodes.find(n => n.id === agent.id);
+    if (!node) {
+      node = {
+        id: agent.id,
+        name: agent.name,
+        icon: agent.icon || DEFAULT_ICON,
+        description: agent.description,
+        apiStatus: agent.status,
+        activityCount: 0,
+        lastActive: 0,
+      };
+      nodes.push(node);
+    } else {
+      node.name = agent.name;
+      node.icon = agent.icon || DEFAULT_ICON;
+      node.description = agent.description;
+      node.apiStatus = agent.status;
     }
-    if (ev.to) {
-      const toNode = getOrCreateNode(ev.to);
-      toNode.activityCount++;
-      toNode.lastActive = Math.max(toNode.lastActive, ev.timestamp);
+  }
+
+  // Remove agents no longer in API
+  nodes = nodes.filter(n => apiIds.has(n.id));
+
+  // Sync static edges from topology
+  for (const te of topology.edges) {
+    let edge = edges.find(e => e.sourceId === te.from && e.targetId === te.to && e.port === te.port);
+    if (!edge) {
+      const sourceNode = nodes.find(n => n.id === te.from);
+      const targetNode = nodes.find(n => n.id === te.to);
+      if (sourceNode && targetNode) {
+        edge = {
+          source: sourceNode,
+          target: targetNode,
+          sourceId: te.from,
+          targetId: te.to,
+          port: te.port,
+          subject: te.subject,
+          messageCount: 0,
+          lastTimestamp: 0,
+          lastType: '',
+        };
+        edges.push(edge);
+      }
+    }
+  }
+
+  // Remove edges whose agents no longer exist
+  edges = edges.filter(e => apiIds.has(e.sourceId) && apiIds.has(e.targetId));
+
+  updateSimulation();
+}
+
+// --- Activity processing ---
+
+function processActivity() {
+  const now = Date.now();
+  const cutoff = now - 5 * 60 * 1000;
+
+  // Reset activity counts
+  nodes.forEach(n => { n.activityCount = 0; });
+
+  // Count per-edge message volume
+  const edgeMessageCounts = new Map<string, number>();
+
+  for (const ev of props.activity) {
+    if (ev.timestamp < cutoff) continue;
+
+    const agentNode = nodes.find(n => n.id === ev.agent);
+    if (agentNode) {
+      agentNode.activityCount++;
+      agentNode.lastActive = Math.max(agentNode.lastActive, ev.timestamp);
     }
 
     if (ev.from && ev.to) {
-      const edge = getOrCreateEdge(ev.from, ev.to);
-      edge.count++;
-      if (ev.timestamp > edge.lastTimestamp) {
-        edge.lastTimestamp = ev.timestamp;
-        edge.lastSummary = ev.summary;
+      const key = edgeKey(ev.from, ev.to);
+      edgeMessageCounts.set(key, (edgeMessageCounts.get(key) ?? 0) + 1);
+
+      // Update edge timestamp
+      const edge = edges.find(e => e.sourceId === ev.from && e.targetId === ev.to);
+      if (edge) {
+        edge.lastTimestamp = Math.max(edge.lastTimestamp, ev.timestamp);
         edge.lastType = ev.subtype || ev.type;
       }
     }
   }
 
-  // Prune stale edges (older than activity window)
-  edges = edges.filter((e) => e.lastTimestamp > cutoff);
+  // Apply message counts to edges
+  for (const edge of edges) {
+    const key = edgeKey(edge.sourceId, edge.targetId);
+    edge.messageCount = edgeMessageCounts.get(key) ?? edge.messageCount;
+  }
 }
 
-// --- Spawn particle for a new event ---
+// --- Particle spawning ---
 
 function spawnParticle(ev: ActivityEvent) {
   if (!ev.from || !ev.to) return;
   const key = edgeKey(ev.from, ev.to);
-  if (!edges.find((e) => e.sourceId === ev.from && e.targetId === ev.to)) return;
+  if (!edges.find(e => e.sourceId === ev.from && e.targetId === ev.to)) return;
   particles.push({
     id: ++particleIdCounter,
     edgeKey: key,
@@ -343,43 +360,37 @@ function spawnParticle(ev: ActivityEvent) {
   });
 }
 
-// --- Detail panel helpers ---
+// --- Detail panel ---
 
-function formatTime(ts: number): string {
-  const d = new Date(ts);
-  return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
-}
-
-async function selectAgent(agentId: string) {
-  const node = nodes.find((n) => n.id === agentId);
+function selectAgent(agentId: string) {
+  const node = nodes.find(n => n.id === agentId);
   if (!node) return;
 
   const agentEvents = props.activity
-    .filter((ev) => ev.agent === agentId || ev.from === agentId)
+    .filter(ev => ev.agent === agentId || ev.from === agentId)
     .sort((a, b) => b.timestamp - a.timestamp);
 
   const current = agentEvents.length > 0 && (Date.now() - agentEvents[0].timestamp < ACTIVE_THRESHOLD_MS)
-    ? agentEvents[0]
-    : null;
+    ? agentEvents[0] : null;
 
-  // Fetch journal entries for this agent
-  let journal: JournalEntry[] = [];
-  try {
-    const res = await fetch('/api/soul/journal');
-    if (res.ok) {
-      const allEntries: JournalEntry[] = await res.json();
-      journal = allEntries.filter((e) => e.agent === agentId);
+  const connections: ConnectionInfo[] = [];
+  for (const edge of edges) {
+    if (edge.sourceId === agentId) {
+      connections.push({ direction: 'out', target: edge.targetId, port: edge.port, messageCount: edge.messageCount });
     }
-  } catch { /* ignore */ }
+    if (edge.targetId === agentId) {
+      connections.push({ direction: 'in', target: edge.sourceId, port: edge.port, messageCount: edge.messageCount });
+    }
+  }
 
   selectedAgent.value = {
     id: node.id,
-    label: node.label,
-    icon: node.icon,
-    active: isActive(node),
+    name: node.name,
+    description: node.description,
+    status: node.apiStatus,
     currentActivity: current,
     recentEvents: agentEvents.slice(0, 10),
-    journal,
+    connections,
   };
 }
 
@@ -391,36 +402,29 @@ function initSvg() {
   width = containerEl.value.clientWidth || 800;
   height = containerEl.value.clientHeight || 600;
 
-  svgSelection = d3.select(svgEl.value)
-    .attr('width', width)
-    .attr('height', height);
-
+  svgSelection = d3.select(svgEl.value).attr('width', width).attr('height', height);
   gSelection = d3.select(rootG.value);
   gSelection.selectAll('*').remove();
 
-  // Layer order: edges -> particles -> nodes (nodes on top)
   edgeGroup = gSelection.append('g').attr('class', 'edges');
   particleGroup = gSelection.append('g').attr('class', 'particles');
   nodeGroup = gSelection.append('g').attr('class', 'nodes');
 
-  // Zoom & pan
   const zoom = d3.zoom<SVGSVGElement, unknown>()
     .scaleExtent([0.3, 3])
-    .on('zoom', (event) => {
-      gSelection!.attr('transform', event.transform);
-    });
+    .on('zoom', (event) => { gSelection!.attr('transform', event.transform); });
 
   svgSelection.call(zoom);
 }
 
 function setupSimulation() {
   simulation = d3.forceSimulation<AgentNode, AgentEdge>(nodes)
-    .force('link', d3.forceLink<AgentNode, AgentEdge>(edges).id((d) => d.id).distance(160).strength(0.4))
-    .force('charge', d3.forceManyBody().strength(-400))
+    .force('link', d3.forceLink<AgentNode, AgentEdge>(edges).id(d => d.id).distance(180).strength(0.3))
+    .force('charge', d3.forceManyBody().strength(-500))
     .force('center', d3.forceCenter(width / 2, height / 2))
-    .force('collision', d3.forceCollide<AgentNode>().radius((d) => nodeRadius(d) + 10))
-    .force('x', d3.forceX(width / 2).strength(0.05))
-    .force('y', d3.forceY(height / 2).strength(0.05))
+    .force('collision', d3.forceCollide<AgentNode>().radius(d => nodeRadius(d) + 15))
+    .force('x', d3.forceX(width / 2).strength(0.04))
+    .force('y', d3.forceY(height / 2).strength(0.04))
     .alphaDecay(0.02)
     .on('tick', renderTick);
 }
@@ -430,189 +434,126 @@ function updateSimulation() {
     setupSimulation();
     return;
   }
-
   simulation.nodes(nodes);
   const linkForce = simulation.force<d3.ForceLink<AgentNode, AgentEdge>>('link');
-  if (linkForce) {
-    linkForce.links(edges);
-  }
-  simulation.force('center', d3.forceCenter(width / 2, height / 2));
+  if (linkForce) linkForce.links(edges);
   simulation.alpha(0.3).restart();
 }
 
 function renderTick() {
   if (!edgeGroup || !nodeGroup || !particleGroup) return;
-
   const now = Date.now();
 
   // --- Edges ---
   const edgeSel = edgeGroup.selectAll<SVGGElement, AgentEdge>('.edge-group')
-    .data(edges, (d) => edgeKey(d.sourceId, d.targetId));
+    .data(edges, d => edgeKey(d.sourceId, d.targetId) + d.port);
 
   const edgeEnter = edgeSel.enter().append('g').attr('class', 'edge-group');
   edgeEnter.append('path').attr('class', 'edge-path');
-  edgeEnter.append('text').attr('class', 'edge-label');
 
   const edgeMerged = edgeEnter.merge(edgeSel);
 
   edgeMerged.select('.edge-path')
-    .attr('d', (d) => {
+    .attr('d', d => {
       const s = d.source as AgentNode;
       const t = d.target as AgentNode;
       return edgePath(s.x || 0, s.y || 0, t.x || 0, t.y || 0);
     })
     .attr('fill', 'none')
-    .attr('stroke', '#6b7280')
-    .attr('stroke-width', (d) => Math.min(1 + d.count * 0.2, 3))
-    .attr('stroke-opacity', (d) => edgeOpacity(d))
+    .attr('stroke', d => edgeColor(d))
+    .attr('stroke-width', d => edgeWidth(d))
+    .attr('stroke-opacity', d => edgeOpacity(d))
     .attr('marker-end', 'url(#arrow)');
-
-  edgeMerged.select('.edge-label')
-    .attr('x', (d) => {
-      const s = d.source as AgentNode;
-      const t = d.target as AgentNode;
-      const pt = pointOnEdge(s.x || 0, s.y || 0, t.x || 0, t.y || 0, 0.5);
-      return pt.x;
-    })
-    .attr('y', (d) => {
-      const s = d.source as AgentNode;
-      const t = d.target as AgentNode;
-      const pt = pointOnEdge(s.x || 0, s.y || 0, t.x || 0, t.y || 0, 0.5);
-      return pt.y - 8;
-    })
-    .attr('text-anchor', 'middle')
-    .attr('fill', '#9ca3af')
-    .attr('font-size', '9px')
-    .attr('opacity', (d) => edgeOpacity(d) * 0.8)
-    .text((d) => truncate(d.lastSummary, 30));
 
   edgeSel.exit().remove();
 
   // --- Nodes ---
   const nodeSel = nodeGroup.selectAll<SVGGElement, AgentNode>('.agent-node')
-    .data(nodes, (d) => d.id);
+    .data(nodes, d => d.id);
 
   const nodeEnter = nodeSel.enter().append('g').attr('class', 'agent-node');
 
-  // Activity ring (pulse outward)
-  nodeEnter.append('circle')
-    .attr('class', 'activity-ring')
-    .attr('r', (d) => nodeRadius(d))
-    .attr('fill', 'none')
-    .attr('stroke', '#7c3aed')
-    .attr('stroke-width', 2)
-    .attr('opacity', 0);
+  nodeEnter.append('circle').attr('class', 'activity-ring')
+    .attr('fill', 'none').attr('stroke', '#7c3aed').attr('stroke-width', 2).attr('opacity', 0);
 
-  // Main circle
-  nodeEnter.append('circle')
-    .attr('class', 'node-circle')
-    .attr('stroke-width', 2);
+  nodeEnter.append('circle').attr('class', 'node-circle').attr('stroke-width', 2);
 
-  // Status indicator dot
-  nodeEnter.append('circle')
-    .attr('class', 'status-dot')
-    .attr('r', 5)
-    .attr('stroke', '#111827')
-    .attr('stroke-width', 1.5);
+  nodeEnter.append('circle').attr('class', 'status-dot')
+    .attr('r', 5).attr('stroke', '#111827').attr('stroke-width', 1.5);
 
-  // Icon text (emoji)
-  nodeEnter.append('text')
-    .attr('class', 'node-icon')
-    .attr('text-anchor', 'middle')
-    .attr('dominant-baseline', 'central')
+  nodeEnter.append('text').attr('class', 'node-icon')
+    .attr('text-anchor', 'middle').attr('dominant-baseline', 'central')
     .attr('pointer-events', 'none');
 
-  // Label text
-  nodeEnter.append('text')
-    .attr('class', 'node-label')
-    .attr('text-anchor', 'middle')
-    .attr('fill', '#d1d5db')
-    .attr('font-size', '11px')
-    .attr('font-weight', '500')
-    .attr('pointer-events', 'none');
+  nodeEnter.append('text').attr('class', 'node-label')
+    .attr('text-anchor', 'middle').attr('fill', '#d1d5db')
+    .attr('font-size', '11px').attr('font-weight', '500').attr('pointer-events', 'none');
 
-  // Click handler for detail panel
-  nodeEnter.on('click', (_event, d) => {
-    selectAgent(d.id);
-  });
+  nodeEnter.on('click', (_event, d) => { selectAgent(d.id); });
 
-  // Drag behavior
   nodeEnter.call(
     d3.drag<SVGGElement, AgentNode>()
       .on('start', (event, d) => {
         if (!event.active) simulation?.alphaTarget(0.2).restart();
-        d.fx = d.x;
-        d.fy = d.y;
+        d.fx = d.x; d.fy = d.y;
       })
-      .on('drag', (event, d) => {
-        d.fx = event.x;
-        d.fy = event.y;
-      })
+      .on('drag', (event, d) => { d.fx = event.x; d.fy = event.y; })
       .on('end', (event, d) => {
         if (!event.active) simulation?.alphaTarget(0);
-        d.fx = null;
-        d.fy = null;
+        d.fx = null; d.fy = null;
       })
   );
 
   const nodeMerged = nodeEnter.merge(nodeSel);
 
-  nodeMerged.attr('transform', (d) => `translate(${d.x || 0},${d.y || 0})`);
+  nodeMerged.attr('transform', d => `translate(${d.x || 0},${d.y || 0})`);
 
   nodeMerged.select('.node-circle')
-    .attr('r', (d) => nodeRadius(d))
-    .attr('fill', (d) => isActive(d) ? 'url(#node-gradient-active)' : 'url(#node-gradient-idle)')
-    .attr('stroke', (d) => isActive(d) ? '#a78bfa' : '#4b5563')
-    .attr('filter', (d) => isActive(d) ? 'url(#agent-glow)' : null);
+    .attr('r', d => nodeRadius(d))
+    .attr('fill', d => isBusy(d) ? 'url(#node-gradient-active)' : 'url(#node-gradient-idle)')
+    .attr('stroke', d => isBusy(d) ? '#a78bfa' : (d.apiStatus === 'running' ? '#4b5563' : '#991b1b'))
+    .attr('filter', d => isBusy(d) ? 'url(#agent-glow)' : null);
 
   nodeMerged.select('.status-dot')
-    .attr('cx', (d) => nodeRadius(d) * 0.7)
-    .attr('cy', (d) => -nodeRadius(d) * 0.7)
-    .attr('fill', (d) => isActive(d) ? '#22c55e' : '#6b7280');
+    .attr('cx', d => nodeRadius(d) * 0.7)
+    .attr('cy', d => -nodeRadius(d) * 0.7)
+    .attr('fill', d => d.apiStatus === 'running' ? (isBusy(d) ? '#22c55e' : '#6b7280') : '#ef4444');
 
   nodeMerged.select('.node-icon')
-    .attr('font-size', (d) => `${nodeRadius(d) * 0.8}px`)
-    .text((d) => d.icon);
+    .attr('font-size', d => `${nodeRadius(d) * 0.8}px`)
+    .text(d => d.icon);
 
   nodeMerged.select('.node-label')
-    .attr('y', (d) => nodeRadius(d) + 16)
-    .text((d) => d.label);
+    .attr('y', d => nodeRadius(d) + 16)
+    .text(d => d.name);
 
-  // Pulse active ring
   nodeMerged.select('.activity-ring')
-    .attr('r', (d) => nodeRadius(d))
-    .attr('stroke', (d) => isActive(d) ? '#7c3aed' : 'none')
-    .attr('opacity', (d) => isActive(d) ? 0.4 + 0.3 * Math.sin(now / 600) : 0)
-    .attr('stroke-width', (d) => isActive(d) ? 2 + Math.sin(now / 600) : 0);
+    .attr('r', d => nodeRadius(d))
+    .attr('stroke', d => isBusy(d) ? '#7c3aed' : 'none')
+    .attr('opacity', d => isBusy(d) ? 0.4 + 0.3 * Math.sin(now / 600) : 0)
+    .attr('stroke-width', d => isBusy(d) ? 2 + Math.sin(now / 600) : 0);
 
   nodeSel.exit().remove();
 
   // --- Particles ---
-  // Advance particles
-  particles = particles.filter((p) => {
+  particles = particles.filter(p => {
     const age = now - p.birth;
     p.progress = age / PARTICLE_DURATION_MS;
     return p.progress < 1;
   });
 
   const particleSel = particleGroup.selectAll<SVGCircleElement, Particle>('.particle')
-    .data(particles, (d) => d.id);
+    .data(particles, d => d.id);
 
   particleSel.enter()
-    .append('circle')
-    .attr('class', 'particle')
-    .attr('r', 4)
-    .attr('opacity', 0.9)
+    .append('circle').attr('class', 'particle').attr('r', 4).attr('opacity', 0.9)
     .merge(particleSel)
-    .attr('fill', (d) => d.color)
-    .attr('opacity', (d) => 1 - d.progress * 0.5)
-    .attr('r', (d) => 3 + (1 - d.progress) * 2)
+    .attr('fill', d => d.color)
+    .attr('opacity', d => 1 - d.progress * 0.5)
+    .attr('r', d => 3 + (1 - d.progress) * 2)
     .each(function (d) {
-      const edge = edges.find((e) => edgeKey(e.sourceId, e.targetId) === d.edgeKey);
-      if (!edge) {
-        d3.select(this).attr('opacity', 0);
-        return;
-      }
+      const edge = edges.find(e => edgeKey(e.sourceId, e.targetId) === d.edgeKey);
+      if (!edge) { d3.select(this).attr('opacity', 0); return; }
       const s = edge.source as AgentNode;
       const t = edge.target as AgentNode;
       const pt = pointOnEdge(s.x || 0, s.y || 0, t.x || 0, t.y || 0, d.progress);
@@ -630,13 +571,6 @@ function startAnimationLoop() {
   animationFrame = requestAnimationFrame(loop);
 }
 
-function stopAnimationLoop() {
-  if (animationFrame !== null) {
-    cancelAnimationFrame(animationFrame);
-    animationFrame = null;
-  }
-}
-
 function handleResize() {
   if (!containerEl.value || !svgSelection) return;
   width = containerEl.value.clientWidth || 800;
@@ -644,8 +578,6 @@ function handleResize() {
   svgSelection.attr('width', width).attr('height', height);
   if (simulation) {
     simulation.force('center', d3.forceCenter(width / 2, height / 2));
-    simulation.force('x', d3.forceX(width / 2).strength(0.05));
-    simulation.force('y', d3.forceY(height / 2).strength(0.05));
     simulation.alpha(0.3).restart();
   }
 }
@@ -657,14 +589,11 @@ let prevActivityLength = 0;
 watch(
   () => props.activity,
   (newActivity) => {
-    // Detect new events (appended to the end)
     const newEvents = newActivity.slice(prevActivityLength);
     prevActivityLength = newActivity.length;
 
-    rebuildGraph();
-    updateSimulation();
+    processActivity();
 
-    // Spawn particles for new events
     for (const ev of newEvents) {
       spawnParticle(ev);
     }
@@ -673,11 +602,13 @@ watch(
 );
 
 onMounted(() => {
-  nextTick(() => {
+  nextTick(async () => {
     initSvg();
-    rebuildGraph();
-    setupSimulation();
+    await loadTopology();
+    processActivity();
     startAnimationLoop();
+
+    topologyInterval = setInterval(loadTopology, TOPOLOGY_POLL_MS);
 
     if (containerEl.value) {
       resizeObserver = new ResizeObserver(() => handleResize());
@@ -687,7 +618,8 @@ onMounted(() => {
 });
 
 onUnmounted(() => {
-  stopAnimationLoop();
+  if (animationFrame !== null) cancelAnimationFrame(animationFrame);
+  if (topologyInterval !== null) clearInterval(topologyInterval);
   simulation?.stop();
   resizeObserver?.disconnect();
 });
@@ -709,22 +641,10 @@ onUnmounted(() => {
   height: 100%;
 }
 
-/* Pulse animation for activity rings */
-.agent-graph-svg :deep(.activity-ring) {
-  transition: opacity 0.3s ease;
-}
-
-/* Particle glow */
 .agent-graph-svg :deep(.particle) {
   filter: drop-shadow(0 0 3px currentColor);
 }
 
-/* Edge hover */
-.agent-graph-svg :deep(.edge-path) {
-  transition: stroke-opacity 0.2s ease;
-}
-
-/* Node cursor */
 .agent-graph-svg :deep(.agent-node) {
   cursor: pointer;
 }
@@ -738,7 +658,7 @@ onUnmounted(() => {
   position: absolute;
   top: 0;
   right: 0;
-  width: 300px;
+  width: 320px;
   height: 100%;
   background: #1e293b;
   border-left: 1px solid #4b5563;
@@ -758,18 +678,11 @@ onUnmounted(() => {
   flex-shrink: 0;
 }
 
-.detail-icon {
-  font-size: 20px;
-}
-
 .detail-name {
   font-size: 14px;
   font-weight: 600;
   color: #e5e7eb;
   flex: 1;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .detail-status {
@@ -778,17 +691,16 @@ onUnmounted(() => {
   border-radius: 10px;
   font-weight: 600;
   text-transform: uppercase;
-  flex-shrink: 0;
 }
 
-.detail-status.active {
+.detail-status.running {
   background: rgba(34, 197, 94, 0.2);
   color: #22c55e;
 }
 
-.detail-status.idle {
-  background: rgba(107, 114, 128, 0.2);
-  color: #9ca3af;
+.detail-status.dead, .detail-status.stopped {
+  background: rgba(239, 68, 68, 0.2);
+  color: #ef4444;
 }
 
 .detail-close {
@@ -799,7 +711,6 @@ onUnmounted(() => {
   cursor: pointer;
   padding: 0 4px;
   line-height: 1;
-  flex-shrink: 0;
 }
 
 .detail-close:hover {
@@ -824,6 +735,12 @@ onUnmounted(() => {
   margin-bottom: 8px;
 }
 
+.detail-desc {
+  font-size: 12px;
+  color: #d1d5db;
+  line-height: 1.4;
+}
+
 .detail-current {
   padding: 8px 10px;
   background: #111827;
@@ -837,45 +754,42 @@ onUnmounted(() => {
   line-height: 1.4;
 }
 
-.detail-current-entity {
-  font-size: 10px;
-  color: #6b7280;
-  margin-top: 4px;
-  font-family: monospace;
+.detail-connections {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
 }
 
-.detail-empty {
-  color: #6b7280;
-  font-size: 12px;
-  padding: 8px 0;
-}
-
-.detail-journal {
-  max-height: 300px;
-  overflow-y: auto;
-}
-
-.journal-entry {
-  margin-bottom: 10px;
-  padding: 8px;
+.detail-conn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
   background: #111827;
-  border-radius: 6px;
-  border-left: 3px solid #7c3aed;
+  border-radius: 4px;
+  font-size: 12px;
 }
 
-.journal-time {
-  font-size: 10px;
+.conn-direction {
+  color: #6b7280;
+  font-weight: 600;
+}
+
+.conn-agent {
+  color: #a78bfa;
+  font-weight: 500;
+}
+
+.conn-port {
   color: #6b7280;
   font-family: monospace;
-  margin-bottom: 4px;
+  font-size: 10px;
 }
 
-.journal-text {
-  font-size: 12px;
-  color: #d1d5db;
-  line-height: 1.5;
-  white-space: pre-wrap;
-  word-break: break-word;
+.conn-count {
+  margin-left: auto;
+  color: #9ca3af;
+  font-size: 10px;
 }
 
 .detail-events {
@@ -904,14 +818,6 @@ onUnmounted(() => {
   line-height: 1.3;
 }
 
-.detail-event-entity {
-  font-size: 10px;
-  color: #6b7280;
-  margin-top: 2px;
-  font-family: monospace;
-}
-
-/* Panel slide transition */
 .panel-slide-enter-active,
 .panel-slide-leave-active {
   transition: transform 0.2s ease, opacity 0.2s ease;

--- a/dashboard/src/modules/soul/AgentGraphView.vue
+++ b/dashboard/src/modules/soul/AgentGraphView.vue
@@ -25,50 +25,6 @@
       <g ref="rootG" class="root-group" />
     </svg>
 
-    <!-- Agent detail panel -->
-    <Transition name="panel-slide">
-      <div v-if="selectedAgent" class="agent-detail-panel">
-        <div class="detail-header">
-          <span class="detail-name">{{ selectedAgent.name }}</span>
-          <span class="detail-status" :class="selectedAgent.status">
-            {{ selectedAgent.status }}
-          </span>
-          <button class="detail-close" @click="selectedAgent = null">&times;</button>
-        </div>
-        <div class="detail-body">
-          <div class="detail-section">
-            <div class="detail-section-title">Description</div>
-            <div class="detail-desc">{{ selectedAgent.description || 'No description' }}</div>
-          </div>
-          <div v-if="selectedAgent.currentActivity" class="detail-section">
-            <div class="detail-section-title">Currently working on</div>
-            <div class="detail-current">
-              <div class="detail-current-summary">{{ selectedAgent.currentActivity.summary }}</div>
-            </div>
-          </div>
-          <div v-if="selectedAgent.connections.length" class="detail-section">
-            <div class="detail-section-title">Connections</div>
-            <div class="detail-connections">
-              <div v-for="conn in selectedAgent.connections" :key="conn.target + conn.port" class="detail-conn">
-                <span class="conn-direction">{{ conn.direction === 'out' ? '→' : '←' }}</span>
-                <span class="conn-agent">{{ conn.target }}</span>
-                <span class="conn-port">{{ conn.port }}</span>
-                <span v-if="conn.messageCount" class="conn-count">{{ conn.messageCount }} msgs</span>
-              </div>
-            </div>
-          </div>
-          <div v-if="selectedAgent.recentEvents.length" class="detail-section">
-            <div class="detail-section-title">Recent activity</div>
-            <div class="detail-events">
-              <div v-for="ev in selectedAgent.recentEvents" :key="ev.timestamp + ev.summary" class="detail-event">
-                <div class="detail-event-time">{{ formatTime(ev.timestamp) }}</div>
-                <div class="detail-event-summary">{{ ev.summary }}</div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </Transition>
   </div>
 </template>
 
@@ -80,6 +36,10 @@ import { fetchAgentTopology } from './SoulApiClient';
 
 const props = defineProps<{
   activity: ActivityEvent[];
+}>();
+
+const emit = defineEmits<{
+  'select-agent': [agentId: string];
 }>();
 
 // --- Types ---
@@ -112,22 +72,7 @@ interface Particle {
   birth: number;
 }
 
-interface ConnectionInfo {
-  direction: 'in' | 'out';
-  target: string;
-  port: string;
-  messageCount: number;
-}
-
-interface SelectedAgentInfo {
-  id: string;
-  name: string;
-  description: string;
-  status: string;
-  currentActivity: ActivityEvent | null;
-  recentEvents: ActivityEvent[];
-  connections: ConnectionInfo[];
-}
+// Detail panel types removed — now in AgentDetailPanel.vue
 
 // --- Constants ---
 
@@ -151,7 +96,7 @@ const TOPOLOGY_POLL_MS = 10_000;
 const containerEl = ref<HTMLElement | null>(null);
 const svgEl = ref<SVGSVGElement | null>(null);
 const rootG = ref<SVGGElement | null>(null);
-const selectedAgent = ref<SelectedAgentInfo | null>(null);
+// selectedAgent removed — parent handles via emit
 
 // --- State ---
 
@@ -360,38 +305,10 @@ function spawnParticle(ev: ActivityEvent) {
   });
 }
 
-// --- Detail panel ---
+// --- Agent selection (emits to parent) ---
 
 function selectAgent(agentId: string) {
-  const node = nodes.find(n => n.id === agentId);
-  if (!node) return;
-
-  const agentEvents = props.activity
-    .filter(ev => ev.agent === agentId || ev.from === agentId)
-    .sort((a, b) => b.timestamp - a.timestamp);
-
-  const current = agentEvents.length > 0 && (Date.now() - agentEvents[0].timestamp < ACTIVE_THRESHOLD_MS)
-    ? agentEvents[0] : null;
-
-  const connections: ConnectionInfo[] = [];
-  for (const edge of edges) {
-    if (edge.sourceId === agentId) {
-      connections.push({ direction: 'out', target: edge.targetId, port: edge.port, messageCount: edge.messageCount });
-    }
-    if (edge.targetId === agentId) {
-      connections.push({ direction: 'in', target: edge.sourceId, port: edge.port, messageCount: edge.messageCount });
-    }
-  }
-
-  selectedAgent.value = {
-    id: node.id,
-    name: node.name,
-    description: node.description,
-    status: node.apiStatus,
-    currentActivity: current,
-    recentEvents: agentEvents.slice(0, 10),
-    connections,
-  };
+  emit('select-agent', agentId);
 }
 
 // --- Rendering ---
@@ -653,179 +570,5 @@ onUnmounted(() => {
   cursor: grabbing;
 }
 
-/* Agent detail panel */
-.agent-detail-panel {
-  position: absolute;
-  top: 0;
-  right: 0;
-  width: 320px;
-  height: 100%;
-  background: #1e293b;
-  border-left: 1px solid #4b5563;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-  box-shadow: -4px 0 24px rgba(0, 0, 0, 0.4);
-  z-index: 10;
-}
-
-.detail-header {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 12px 14px;
-  border-bottom: 1px solid #4b5563;
-  flex-shrink: 0;
-}
-
-.detail-name {
-  font-size: 14px;
-  font-weight: 600;
-  color: #e5e7eb;
-  flex: 1;
-}
-
-.detail-status {
-  font-size: 10px;
-  padding: 2px 8px;
-  border-radius: 10px;
-  font-weight: 600;
-  text-transform: uppercase;
-}
-
-.detail-status.running {
-  background: rgba(34, 197, 94, 0.2);
-  color: #22c55e;
-}
-
-.detail-status.dead, .detail-status.stopped {
-  background: rgba(239, 68, 68, 0.2);
-  color: #ef4444;
-}
-
-.detail-close {
-  background: none;
-  border: none;
-  color: #9ca3af;
-  font-size: 20px;
-  cursor: pointer;
-  padding: 0 4px;
-  line-height: 1;
-}
-
-.detail-close:hover {
-  color: #f3f4f6;
-}
-
-.detail-body {
-  overflow-y: auto;
-  padding: 12px 14px;
-  flex: 1;
-}
-
-.detail-section {
-  margin-bottom: 16px;
-}
-
-.detail-section-title {
-  font-size: 11px;
-  font-weight: 600;
-  color: #9ca3af;
-  text-transform: uppercase;
-  margin-bottom: 8px;
-}
-
-.detail-desc {
-  font-size: 12px;
-  color: #d1d5db;
-  line-height: 1.4;
-}
-
-.detail-current {
-  padding: 8px 10px;
-  background: #111827;
-  border-radius: 6px;
-  border-left: 3px solid #7c3aed;
-}
-
-.detail-current-summary {
-  font-size: 12px;
-  color: #d1d5db;
-  line-height: 1.4;
-}
-
-.detail-connections {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
-.detail-conn {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 4px 8px;
-  background: #111827;
-  border-radius: 4px;
-  font-size: 12px;
-}
-
-.conn-direction {
-  color: #6b7280;
-  font-weight: 600;
-}
-
-.conn-agent {
-  color: #a78bfa;
-  font-weight: 500;
-}
-
-.conn-port {
-  color: #6b7280;
-  font-family: monospace;
-  font-size: 10px;
-}
-
-.conn-count {
-  margin-left: auto;
-  color: #9ca3af;
-  font-size: 10px;
-}
-
-.detail-events {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.detail-event {
-  padding: 6px 10px;
-  background: #111827;
-  border-radius: 6px;
-  border-left: 3px solid #4b5563;
-}
-
-.detail-event-time {
-  font-size: 10px;
-  color: #6b7280;
-  margin-bottom: 2px;
-  font-family: monospace;
-}
-
-.detail-event-summary {
-  font-size: 12px;
-  color: #d1d5db;
-  line-height: 1.3;
-}
-
-.panel-slide-enter-active,
-.panel-slide-leave-active {
-  transition: transform 0.2s ease, opacity 0.2s ease;
-}
-
-.panel-slide-enter-from,
-.panel-slide-leave-to {
-  transform: translateX(20px);
-  opacity: 0;
-}
+/* Detail panel CSS removed — now in AgentDetailPanel.vue */
 </style>

--- a/dashboard/src/modules/soul/ChatPanel.vue
+++ b/dashboard/src/modules/soul/ChatPanel.vue
@@ -1,0 +1,391 @@
+<script setup lang="ts">
+import { ref, computed, watch, onMounted, onUnmounted, nextTick } from 'vue';
+import { fetchThreads, fetchMessages, sendMessage, createThread } from './SoulApiClient';
+import type { ChatThread, ChatMessage } from './SoulApiClient';
+
+const minimized = ref(true);
+const threads = ref<ChatThread[]>([]);
+const activeThread = ref('main');
+const messages = ref<ChatMessage[]>([]);
+const inputText = ref('');
+const sending = ref(false);
+const messagesEl = ref<HTMLElement | null>(null);
+
+let pollTimer: ReturnType<typeof setInterval> | null = null;
+
+const pendingCount = computed(() =>
+  threads.value.filter((t) => t.pending).length,
+);
+
+function formatTime(ts: number): string {
+  const d = new Date(ts);
+  return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+}
+
+async function scrollToBottom(): Promise<void> {
+  await nextTick();
+  if (messagesEl.value) {
+    messagesEl.value.scrollTop = messagesEl.value.scrollHeight;
+  }
+}
+
+async function loadThreads(): Promise<void> {
+  threads.value = await fetchThreads();
+  if (threads.value.length > 0 && !threads.value.find((t) => t.id === activeThread.value)) {
+    activeThread.value = threads.value[0].id;
+  }
+}
+
+async function loadMessages(): Promise<void> {
+  messages.value = await fetchMessages(activeThread.value);
+  await scrollToBottom();
+}
+
+async function send(): Promise<void> {
+  const text = inputText.value.trim();
+  if (!text || sending.value) return;
+
+  const userMsg: ChatMessage = { role: 'user', text, ts: Date.now() };
+  messages.value = [...messages.value, userMsg];
+  inputText.value = '';
+  sending.value = true;
+  await scrollToBottom();
+
+  try {
+    const reply = await sendMessage(activeThread.value, text);
+    if (reply) {
+      const agentMsg: ChatMessage = { role: 'agent', text: reply, ts: Date.now() };
+      messages.value = [...messages.value, agentMsg];
+    }
+  } finally {
+    sending.value = false;
+    await scrollToBottom();
+  }
+}
+
+async function addThread(): Promise<void> {
+  const title = `Thread ${threads.value.length + 1}`;
+  const created = await createThread(title);
+  if (created) {
+    threads.value = [...threads.value, created];
+    activeThread.value = created.id;
+  }
+}
+
+watch(activeThread, () => {
+  loadMessages();
+});
+
+onMounted(async () => {
+  await loadThreads();
+  await loadMessages();
+  pollTimer = setInterval(loadThreads, 5000);
+});
+
+onUnmounted(() => {
+  if (pollTimer) {
+    clearInterval(pollTimer);
+    pollTimer = null;
+  }
+});
+</script>
+
+<template>
+  <!-- Minimized: bubble -->
+  <div v-if="minimized" class="chat-bubble" @click="minimized = false">
+    💬
+    <span v-if="pendingCount > 0" class="badge">{{ pendingCount }}</span>
+  </div>
+
+  <!-- Expanded: full panel -->
+  <div v-else class="chat-panel">
+    <!-- Header with tabs -->
+    <div class="chat-header">
+      <div class="chat-tabs">
+        <div
+          v-for="t in threads"
+          :key="t.id"
+          class="chat-tab"
+          :class="{ active: activeThread === t.id }"
+          @click="activeThread = t.id"
+        >
+          {{ t.title }}
+          <span v-if="t.pending" class="tab-badge"></span>
+        </div>
+        <div class="chat-tab add-tab" @click="addThread">+</div>
+      </div>
+      <button class="minimize-btn" @click="minimized = true">▼</button>
+    </div>
+
+    <!-- Messages -->
+    <div ref="messagesEl" class="chat-messages">
+      <div
+        v-for="msg in messages"
+        :key="msg.ts"
+        class="chat-msg"
+        :class="msg.role"
+      >
+        <div class="msg-text">{{ msg.text }}</div>
+        <div class="msg-time">{{ formatTime(msg.ts) }}</div>
+      </div>
+      <div v-if="sending" class="chat-msg agent typing">
+        <div class="msg-text">...</div>
+      </div>
+    </div>
+
+    <!-- Input -->
+    <div class="chat-input">
+      <input
+        v-model="inputText"
+        placeholder="Napiste zpravu..."
+        :disabled="sending"
+        @keydown.enter="send"
+      />
+      <button :disabled="!inputText.trim() || sending" @click="send">➤</button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+/* ── Bubble ──────────────────────────────────────────────────── */
+.chat-bubble {
+  position: fixed;
+  bottom: 16px;
+  right: 16px;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: #7c3aed;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  font-size: 22px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  z-index: 50;
+  user-select: none;
+}
+
+.chat-bubble .badge {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  min-width: 18px;
+  height: 18px;
+  border-radius: 9px;
+  background: #ef4444;
+  color: #fff;
+  font-size: 11px;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 4px;
+}
+
+/* ── Panel ───────────────────────────────────────────────────── */
+.chat-panel {
+  position: fixed;
+  bottom: 16px;
+  right: 16px;
+  width: 360px;
+  height: 480px;
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 12px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+  z-index: 50;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+/* ── Header / Tabs ───────────────────────────────────────────── */
+.chat-header {
+  display: flex;
+  align-items: center;
+  border-bottom: 1px solid #334155;
+  background: #0f172a;
+  min-height: 38px;
+}
+
+.chat-tabs {
+  display: flex;
+  flex: 1;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.chat-tabs::-webkit-scrollbar {
+  display: none;
+}
+
+.chat-tab {
+  position: relative;
+  padding: 8px 14px;
+  font-size: 12px;
+  color: #94a3b8;
+  cursor: pointer;
+  white-space: nowrap;
+  border-bottom: 2px solid transparent;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.chat-tab:hover {
+  color: #e2e8f0;
+}
+
+.chat-tab.active {
+  color: #e2e8f0;
+  border-bottom-color: #7c3aed;
+}
+
+.chat-tab.add-tab {
+  color: #64748b;
+  font-weight: 700;
+  font-size: 14px;
+}
+
+.chat-tab.add-tab:hover {
+  color: #7c3aed;
+}
+
+.tab-badge {
+  position: absolute;
+  top: 6px;
+  right: 4px;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #ef4444;
+}
+
+.minimize-btn {
+  background: none;
+  border: none;
+  color: #64748b;
+  font-size: 14px;
+  cursor: pointer;
+  padding: 8px 10px;
+  transition: color 0.15s;
+}
+
+.minimize-btn:hover {
+  color: #e2e8f0;
+}
+
+/* ── Messages ────────────────────────────────────────────────── */
+.chat-messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.chat-messages::-webkit-scrollbar {
+  width: 4px;
+}
+
+.chat-messages::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.chat-messages::-webkit-scrollbar-thumb {
+  background: #334155;
+  border-radius: 2px;
+}
+
+.chat-msg {
+  max-width: 80%;
+  padding: 8px 12px;
+  border-radius: 10px;
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.chat-msg.user {
+  align-self: flex-end;
+  background: #4c1d95;
+  color: #e2e8f0;
+}
+
+.chat-msg.agent {
+  align-self: flex-start;
+  background: #334155;
+  color: #e2e8f0;
+}
+
+.chat-msg.typing {
+  opacity: 0.6;
+}
+
+.msg-text {
+  word-break: break-word;
+}
+
+.msg-time {
+  font-size: 10px;
+  color: #64748b;
+  margin-top: 4px;
+}
+
+.chat-msg.user .msg-time {
+  text-align: right;
+}
+
+/* ── Input ───────────────────────────────────────────────────── */
+.chat-input {
+  display: flex;
+  gap: 6px;
+  padding: 8px 10px;
+  border-top: 1px solid #334155;
+  background: #0f172a;
+}
+
+.chat-input input {
+  flex: 1;
+  background: #1e293b;
+  border: 1px solid #475569;
+  border-radius: 8px;
+  padding: 8px 12px;
+  color: #e2e8f0;
+  font-size: 13px;
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.chat-input input::placeholder {
+  color: #64748b;
+}
+
+.chat-input input:focus {
+  border-color: #7c3aed;
+}
+
+.chat-input input:disabled {
+  opacity: 0.5;
+}
+
+.chat-input button {
+  background: #7c3aed;
+  border: none;
+  border-radius: 8px;
+  color: #fff;
+  font-size: 16px;
+  width: 36px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.chat-input button:hover:not(:disabled) {
+  background: #6d28d9;
+}
+
+.chat-input button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+</style>

--- a/dashboard/src/modules/soul/MindMapView.vue
+++ b/dashboard/src/modules/soul/MindMapView.vue
@@ -1,787 +1,345 @@
 <template>
-  <div ref="containerEl" class="mindmap-container">
-    <svg ref="svgEl" class="mindmap-svg">
-      <defs>
-        <filter id="glow-green">
-          <feGaussianBlur stdDeviation="3" result="blur" />
-          <feMerge><feMergeNode in="blur" /><feMergeNode in="SourceGraphic" /></feMerge>
-        </filter>
-        <filter id="glow-blue">
-          <feGaussianBlur stdDeviation="2.5" result="blur" />
-          <feMerge><feMergeNode in="blur" /><feMergeNode in="SourceGraphic" /></feMerge>
-        </filter>
-      </defs>
-      <g ref="rootG" class="root-group" />
-    </svg>
+  <div class="mind-map-tree">
+    <div class="tree-header">
+      <h3>🗺️ Mind Map</h3>
+      <label class="toggle-completed">
+        <input type="checkbox" v-model="showCompleted" />
+        Show completed
+      </label>
+    </div>
 
-    <!-- Entity detail panel -->
-    <Transition name="panel-slide">
-      <div v-if="selectedNode" class="detail-panel">
-        <div class="detail-header">
-          <span class="detail-type-badge" :class="selectedNode.type">{{ selectedNode.type }}</span>
-          <span class="detail-title">{{ selectedNode.title }}</span>
-          <button class="detail-close" @click="selectedNode = null">&times;</button>
+    <div class="tree-content">
+      <!-- Goals -->
+      <div v-for="goal in filteredGoals" :key="goal.id" class="tree-node goal-node">
+        <div class="node-header" @click="toggle(goal.id)">
+          <span class="expand-icon">{{ expanded[goal.id] ? '▼' : '▶' }}</span>
+          <span class="node-icon">🎯</span>
+          <span class="node-title">{{ goal.title }}</span>
+          <span class="node-badge" :class="goal.status">{{ goal.status }}</span>
         </div>
-        <div class="detail-body">
-          <!-- Status row -->
-          <div class="detail-meta-row">
-            <span class="detail-meta-label">Status</span>
-            <span class="detail-meta-status" :class="selectedNode.status">{{ selectedNode.status }}</span>
-          </div>
 
-          <!-- Goal-specific info -->
-          <template v-if="selectedNode.type === 'goal'">
-            <div class="detail-meta-row">
-              <span class="detail-meta-label">Ideas</span>
-              <span class="detail-meta-value">{{ selectedNode.ideaCount }}</span>
+        <div v-if="expanded[goal.id]" class="node-children">
+          <!-- Ideas under this goal -->
+          <div v-for="idea in filterItems(goal.ideas)" :key="idea.id" class="tree-node idea-node">
+            <div class="node-header" @click="toggle(idea.id)">
+              <span class="expand-icon">{{ expanded[idea.id] ? '▼' : '▶' }}</span>
+              <span class="node-icon">💡</span>
+              <span class="node-title">{{ idea.title }}</span>
+              <span v-if="idea.conscience_verdict" class="verdict-badge" :class="idea.conscience_verdict">
+                {{ idea.conscience_verdict }}
+              </span>
             </div>
-            <div class="detail-meta-row">
-              <span class="detail-meta-label">Plans</span>
-              <span class="detail-meta-value">{{ selectedNode.planCount }}</span>
-            </div>
-          </template>
 
-          <!-- Idea-specific info -->
-          <template v-if="selectedNode.type === 'idea'">
-            <div v-if="selectedNode.conscienceVerdict" class="detail-meta-row">
-              <span class="detail-meta-label">Conscience</span>
-              <span class="turn-verdict" :class="selectedNode.conscienceVerdict">{{ selectedNode.conscienceVerdict }}</span>
-            </div>
-            <div class="detail-meta-row">
-              <span class="detail-meta-label">Plans</span>
-              <span class="detail-meta-value">{{ selectedNode.planCount }}</span>
-            </div>
-          </template>
-
-          <!-- Description -->
-          <div v-if="selectedNode.description" class="detail-section">
-            <div class="detail-section-title">Description</div>
-            <div class="detail-description">{{ selectedNode.description }}</div>
-          </div>
-
-          <!-- Dialogue history (ideas) -->
-          <div v-if="selectedNode.dialogue && selectedNode.dialogue.length" class="detail-section">
-            <div class="detail-section-title">Dialogue history</div>
-            <div
-              v-for="turn in selectedNode.dialogue"
-              :key="turn.turn"
-              class="dialogue-turn"
-              :class="{ boundary: turn.boundary, verdict: turn.verdict }"
-            >
-              <div class="turn-meta">
-                <span class="turn-agent">{{ turn.agent }}</span>
-                <span v-if="turn.verdict" class="turn-verdict" :class="turn.verdict">{{ turn.verdict }}</span>
-                <span v-if="turn.boundary" class="turn-boundary">{{ turn.boundary }}</span>
+            <div v-if="expanded[idea.id]" class="node-children">
+              <!-- Conscience reason -->
+              <div v-if="idea.conscience_reason" class="node-detail">
+                <span class="detail-label">⚖️ Conscience:</span>
+                {{ idea.conscience_reason.substring(0, 150) }}{{ idea.conscience_reason.length > 150 ? '...' : '' }}
               </div>
-              <div v-if="turn.reason" class="turn-text">{{ turn.reason }}</div>
-              <div v-if="turn.argument" class="turn-text turn-argument">{{ turn.argument }}</div>
-            </div>
-          </div>
 
-          <!-- Tasks (plans) -->
-          <div v-if="selectedNode.tasks && selectedNode.tasks.length" class="detail-section">
-            <div class="detail-section-title">Tasks</div>
-            <div v-for="task in selectedNode.tasks" :key="task.id" class="task-item" :class="{ done: task.done }">
-              <span class="task-check">{{ task.done ? '✓' : '○' }}</span>
-              {{ task.title }}
+              <!-- Plans under this idea -->
+              <div v-for="plan in idea.plans" :key="plan.id" class="tree-node plan-node">
+                <div class="node-header" @click="toggle(plan.id)">
+                  <span class="expand-icon">{{ expanded[plan.id] ? '▼' : '▶' }}</span>
+                  <span class="node-icon">📋</span>
+                  <span class="node-title">{{ plan.title }}</span>
+                  <span class="node-badge" :class="plan.status">{{ plan.status }}</span>
+                </div>
+
+                <div v-if="expanded[plan.id]" class="node-children">
+                  <!-- Tasks -->
+                  <div v-for="task in plan.tasks" :key="task.id" class="tree-node task-node">
+                    <div class="node-header">
+                      <span class="task-check">{{ task.done ? '✅' : '⬜' }}</span>
+                      <span class="node-title" :class="{ done: task.done }">{{ task.title }}</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
         </div>
       </div>
-    </Transition>
+
+      <!-- Orphan ideas (no goal) -->
+      <div v-if="filteredOrphans.length" class="tree-section">
+        <div class="section-label">Orphan Ideas</div>
+        <div v-for="idea in filteredOrphans" :key="idea.id" class="tree-node idea-node">
+          <div class="node-header" @click="toggle(idea.id)">
+            <span class="expand-icon">{{ expanded[idea.id] ? '▼' : '▶' }}</span>
+            <span class="node-icon">💡</span>
+            <span class="node-title">{{ idea.title }}</span>
+            <span v-if="idea.conscience_verdict" class="verdict-badge" :class="idea.conscience_verdict">
+              {{ idea.conscience_verdict }}
+            </span>
+          </div>
+
+          <div v-if="expanded[idea.id]" class="node-children">
+            <div v-if="idea.conscience_reason" class="node-detail">
+              <span class="detail-label">⚖️ Conscience:</span>
+              {{ idea.conscience_reason.substring(0, 150) }}{{ idea.conscience_reason.length > 150 ? '...' : '' }}
+            </div>
+
+            <div v-for="plan in idea.plans" :key="plan.id" class="tree-node plan-node">
+              <div class="node-header" @click="toggle(plan.id)">
+                <span class="expand-icon">{{ expanded[plan.id] ? '▼' : '▶' }}</span>
+                <span class="node-icon">📋</span>
+                <span class="node-title">{{ plan.title }}</span>
+                <span class="node-badge" :class="plan.status">{{ plan.status }}</span>
+              </div>
+
+              <div v-if="expanded[plan.id]" class="node-children">
+                <div v-for="task in plan.tasks" :key="task.id" class="tree-node task-node">
+                  <div class="node-header">
+                    <span class="task-check">{{ task.done ? '✅' : '⬜' }}</span>
+                    <span class="node-title" :class="{ done: task.done }">{{ task.title }}</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div v-if="filteredGoals.length === 0 && filteredOrphans.length === 0" class="empty">
+        No active goals or ideas
+      </div>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, watch, onMounted, onUnmounted, nextTick } from 'vue';
-import * as d3 from 'd3';
-import type { SoulState, ActivityEvent, DialogueTurn, SoulTask } from './SoulApiClient';
+import { ref, computed } from 'vue';
+import type { SoulState, SoulIdea, ActivityEvent } from './SoulApiClient';
 
 const props = defineProps<{
   state: SoulState;
   activity: ActivityEvent[];
 }>();
 
-interface TreeNode {
-  id: string;
-  title: string;
-  status: string;
-  type: 'root' | 'goal' | 'idea' | 'plan';
-  dialogue?: DialogueTurn[];
-  tasks?: SoulTask[];
-  children?: TreeNode[];
+const showCompleted = ref(false);
+const expanded = ref<Record<string, boolean>>({});
+
+function toggle(id: string) {
+  expanded.value[id] = !expanded.value[id];
 }
 
-interface SelectedNodeInfo {
-  title: string;
-  description?: string;
-  type: 'root' | 'goal' | 'idea' | 'plan';
-  status: string;
-  dialogue?: DialogueTurn[];
-  tasks?: SoulTask[];
-  conscienceVerdict?: string;
-  ideaCount?: number;
-  planCount?: number;
+const HIDDEN_STATUSES = ['done', 'superseded', 'completed', 'rejected'];
+
+function isHidden(status: string): boolean {
+  return !showCompleted.value && HIDDEN_STATUSES.includes(status);
 }
 
-const containerEl = ref<HTMLElement | null>(null);
-const svgEl = ref<SVGSVGElement | null>(null);
-const rootG = ref<SVGGElement | null>(null);
-const selectedNode = ref<SelectedNodeInfo | null>(null);
-
-const STATUS_COLORS: Record<string, string> = {
-  pending: '#6b7280',
-  approved: '#3b82f6',
-  in_progress: '#22c55e',
-  done: '#22c55e',
-  rejected: '#ef4444',
-  boundary: '#f59e0b',
-};
-
-const TYPE_RADIUS: Record<string, number> = {
-  root: 20,
-  goal: 16,
-  idea: 12,
-  plan: 9,
-};
-
-function getColor(status: string): string {
-  return STATUS_COLORS[status] || STATUS_COLORS.pending;
-}
-
-function truncate(text: string, max: number): string {
-  return text.length > max ? text.slice(0, max - 1) + '…' : text;
-}
-
-function buildHierarchy(state: SoulState): TreeNode {
-  const root: TreeNode = {
-    id: '__root__',
-    title: 'Thinking',
-    status: 'approved',
-    type: 'root',
-    children: [],
-  };
-
-  for (const goal of state.goals) {
-    const goalNode: TreeNode = {
-      id: goal.id,
-      title: goal.title,
-      status: goal.status,
-      type: 'goal',
-      children: [],
-    };
-    for (const idea of goal.ideas) {
-      const ideaNode: TreeNode = {
-        id: idea.id,
-        title: idea.title,
-        status: idea.conscience_verdict === 'boundary' ? 'boundary' : idea.status,
-        type: 'idea',
-        dialogue: idea.dialogue,
-        children: [],
-      };
-      for (const plan of idea.plans) {
-        ideaNode.children!.push({
-          id: plan.id,
-          title: plan.title,
-          status: plan.status,
-          type: 'plan',
-          tasks: plan.tasks,
-        });
-      }
-      goalNode.children!.push(ideaNode);
-    }
-    root.children!.push(goalNode);
-  }
-
-  // Orphan ideas as direct children of root
-  for (const idea of state.orphanIdeas) {
-    const ideaNode: TreeNode = {
-      id: idea.id,
-      title: idea.title,
-      status: idea.conscience_verdict === 'boundary' ? 'boundary' : idea.status,
-      type: 'idea',
-      dialogue: idea.dialogue,
-      children: [],
-    };
-    for (const plan of idea.plans) {
-      ideaNode.children!.push({
-        id: plan.id,
-        title: plan.title,
-        status: plan.status,
-        type: 'plan',
-        tasks: plan.tasks,
-      });
-    }
-    root.children!.push(ideaNode);
-  }
-
-  // Orphan plans as direct children of root
-  for (const plan of state.orphanPlans) {
-    root.children!.push({
-      id: plan.id,
-      title: plan.title,
-      status: plan.status,
-      type: 'plan',
-      tasks: plan.tasks,
-    });
-  }
-
-  return root;
-}
-
-function activeAgentMap(activity: ActivityEvent[]): Map<string, string[]> {
-  // Map entityId -> list of agent names currently active on it
-  const map = new Map<string, string[]>();
-  const cutoff = Date.now() - 30_000; // last 30 seconds
-  for (const ev of activity) {
-    if (ev.entityId && ev.timestamp > cutoff) {
-      const list = map.get(ev.entityId) || [];
-      if (!list.includes(ev.agent)) list.push(ev.agent);
-      map.set(ev.entityId, list);
-    }
-  }
-  return map;
-}
-
-function render() {
-  if (!svgEl.value || !rootG.value || !containerEl.value) return;
-
-  const container = containerEl.value;
-  const width = container.clientWidth || 800;
-  const height = container.clientHeight || 600;
-
-  const svg = d3.select(svgEl.value)
-    .attr('width', width)
-    .attr('height', height);
-
-  const g = d3.select(rootG.value);
-  g.selectAll('*').remove();
-
-  const hierarchy = buildHierarchy(props.state);
-
-  // If there's nothing to render, show a placeholder
-  if (!hierarchy.children || hierarchy.children.length === 0) {
-    g.append('text')
-      .attr('x', width / 2)
-      .attr('y', height / 2)
-      .attr('text-anchor', 'middle')
-      .attr('fill', '#6b7280')
-      .attr('font-size', '14px')
-      .text('No goals or ideas yet');
-    return;
-  }
-
-  const root = d3.hierarchy(hierarchy);
-  const margin = { top: 40, right: 120, bottom: 40, left: 120 };
-  const innerWidth = width - margin.left - margin.right;
-  const innerHeight = height - margin.top - margin.bottom;
-
-  const treeLayout = d3.tree<TreeNode>()
-    .size([innerHeight, innerWidth])
-    .separation((a, b) => (a.parent === b.parent ? 1.2 : 2));
-
-  treeLayout(root);
-
-  const mainG = g.append('g')
-    .attr('transform', `translate(${margin.left},${margin.top})`);
-
-  // Curved links
-  const linkGenerator = d3.linkHorizontal<d3.HierarchyLink<TreeNode>, d3.HierarchyPointNode<TreeNode>>()
-    .x((d: any) => d.y)
-    .y((d: any) => d.x);
-
-  mainG.selectAll('.link')
-    .data(root.links())
-    .join('path')
-    .attr('class', 'link')
-    .attr('d', linkGenerator as any)
-    .attr('fill', 'none')
-    .attr('stroke', (d) => {
-      const targetColor = getColor(d.target.data.status);
-      return targetColor;
-    })
-    .attr('stroke-opacity', 0.35)
-    .attr('stroke-width', 1.5);
-
-  // Agent activity map
-  const agentMap = activeAgentMap(props.activity);
-
-  // Nodes
-  const nodeGroups = mainG.selectAll('.node')
-    .data(root.descendants())
-    .join('g')
-    .attr('class', 'node')
-    .attr('transform', (d) => `translate(${d.y},${d.x})`)
-    .style('cursor', (d) => d.data.type !== 'root' ? 'pointer' : 'default')
-    .on('click', (_event, d) => {
-      const data = d.data;
-      if (data.type === 'root') return;
-
-      // Find source data for description
-      const allGoals = props.state.goals;
-      const allIdeas = [...allGoals.flatMap((g) => g.ideas), ...props.state.orphanIdeas];
-      const allPlans = [...allIdeas.flatMap((i) => i.plans), ...props.state.orphanPlans];
-
-      let description: string | undefined;
-      if (data.type === 'goal') description = allGoals.find((g) => g.id === data.id)?.description;
-      else if (data.type === 'idea') description = allIdeas.find((i) => i.id === data.id)?.description;
-      else if (data.type === 'plan') description = allPlans.find((p) => p.id === data.id)?.description;
-
-      const info: SelectedNodeInfo = {
-        title: data.title,
-        description,
-        type: data.type,
-        status: data.status,
-        dialogue: data.dialogue,
-        tasks: data.tasks,
-      };
-
-      if (data.type === 'goal') {
-        info.ideaCount = data.children?.filter((c) => c.type === 'idea').length || 0;
-        info.planCount = data.children?.reduce((sum, c) =>
-          sum + (c.type === 'plan' ? 1 : (c.children?.filter((p) => p.type === 'plan').length || 0)), 0) || 0;
-      }
-
-      if (data.type === 'idea') {
-        const srcIdea = allIdeas.find((i) => i.id === data.id);
-        info.conscienceVerdict = srcIdea?.conscience_verdict;
-        info.planCount = data.children?.filter((c) => c.type === 'plan').length || 0;
-      }
-
-      selectedNode.value = info;
-    });
-
-  // Node circles
-  nodeGroups.append('circle')
-    .attr('r', (d) => TYPE_RADIUS[d.data.type] || 10)
-    .attr('fill', (d) => {
-      const color = getColor(d.data.status);
-      return d.data.status === 'done' ? color : d3.color(color)!.copy({ opacity: 0.2 }).formatRgb();
-    })
-    .attr('stroke', (d) => getColor(d.data.status))
-    .attr('stroke-width', (d) => d.data.type === 'root' ? 3 : 2)
-    .attr('filter', (d) => d.data.status === 'in_progress' ? 'url(#glow-green)' : null)
-    .each(function (d) {
-      if (d.data.status === 'in_progress') {
-        d3.select(this).classed('pulse', true);
-      }
-    });
-
-  // Labels
-  nodeGroups.append('text')
-    .attr('dy', (d) => {
-      const r = TYPE_RADIUS[d.data.type] || 10;
-      return -(r + 6);
-    })
-    .attr('text-anchor', 'middle')
-    .attr('fill', '#d1d5db')
-    .attr('font-size', (d) => d.data.type === 'root' ? '13px' : d.data.type === 'goal' ? '12px' : '11px')
-    .attr('font-weight', (d) => d.data.type === 'root' || d.data.type === 'goal' ? '600' : '400')
-    .text((d) => truncate(d.data.title, d.data.type === 'root' ? 20 : d.data.type === 'goal' ? 28 : 24));
-
-  // Type badges (small text below node)
-  nodeGroups.filter((d) => d.data.type !== 'root')
-    .append('text')
-    .attr('dy', (d) => {
-      const r = TYPE_RADIUS[d.data.type] || 10;
-      return r + 14;
-    })
-    .attr('text-anchor', 'middle')
-    .attr('fill', '#4b5563')
-    .attr('font-size', '9px')
-    .attr('text-transform', 'uppercase')
-    .text((d) => d.data.type);
-
-  // Agent indicators
-  nodeGroups.each(function (d) {
-    const agents = agentMap.get(d.data.id);
-    if (!agents || agents.length === 0) return;
-    const group = d3.select(this);
-    const r = TYPE_RADIUS[d.data.type] || 10;
-
-    agents.forEach((agent, i) => {
-      const angle = (-Math.PI / 4) + (i * Math.PI / 6);
-      const dist = r + 12;
-      const ax = Math.cos(angle) * dist;
-      const ay = Math.sin(angle) * dist;
-
-      const agentG = group.append('g')
-        .attr('transform', `translate(${ax},${ay})`);
-
-      agentG.append('circle')
-        .attr('r', 6)
-        .attr('fill', '#7c3aed')
-        .attr('stroke', '#1f2937')
-        .attr('stroke-width', 1.5)
-        .classed('agent-pulse', true);
-
-      agentG.append('text')
-        .attr('text-anchor', 'middle')
-        .attr('dy', '0.35em')
-        .attr('fill', '#fff')
-        .attr('font-size', '7px')
-        .attr('font-weight', '700')
-        .text(agent.charAt(0).toUpperCase());
-    });
-  });
-
-  // Zoom & pan
-  const zoom = d3.zoom<SVGSVGElement, unknown>()
-    .scaleExtent([0.3, 3])
-    .on('zoom', (event) => {
-      g.attr('transform', event.transform);
-    });
-
-  svg.call(zoom);
-
-  // Auto-fit: compute bounds and center
-  const bounds = (mainG.node() as SVGGElement)?.getBBox();
-  if (bounds) {
-    const fullWidth = bounds.width + margin.left + margin.right;
-    const fullHeight = bounds.height + margin.top + margin.bottom;
-    const scale = Math.min(
-      width / fullWidth,
-      height / fullHeight,
-      1.2
-    );
-    const tx = (width - fullWidth * scale) / 2;
-    const ty = (height - fullHeight * scale) / 2;
-    svg.call(zoom.transform, d3.zoomIdentity.translate(tx, ty).scale(scale));
-  }
-}
-
-// Resize observer
-let resizeObserver: ResizeObserver | null = null;
-
-onMounted(() => {
-  nextTick(() => render());
-
-  if (containerEl.value) {
-    resizeObserver = new ResizeObserver(() => render());
-    resizeObserver.observe(containerEl.value);
-  }
+const filteredGoals = computed(() => {
+  return props.state.goals.filter(g => !isHidden(g.status));
 });
 
-onUnmounted(() => {
-  resizeObserver?.disconnect();
+const filteredOrphans = computed(() => {
+  return (props.state.orphanIdeas ?? []).filter(i => !isHidden(i.status));
 });
 
-watch(() => props.state, () => render(), { deep: true });
-watch(() => props.activity, () => render(), { deep: true });
+function filterItems(items: SoulIdea[]): SoulIdea[] {
+  return items.filter(i => !isHidden(i.status));
+}
 </script>
 
 <style scoped>
-.mindmap-container {
-  position: relative;
+.mind-map-tree {
   width: 100%;
   height: 100%;
-  min-height: 300px;
-  overflow: hidden;
-}
-
-.mindmap-svg {
-  display: block;
-  width: 100%;
-  height: 100%;
-}
-
-/* Pulse animation for in_progress nodes */
-.mindmap-svg :deep(.pulse) {
-  animation: node-pulse 2s ease-in-out infinite;
-}
-
-.mindmap-svg :deep(.agent-pulse) {
-  animation: agent-glow 1.5s ease-in-out infinite alternate;
-}
-
-@keyframes node-pulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.5; }
-}
-
-@keyframes agent-glow {
-  0% { filter: brightness(1); }
-  100% { filter: brightness(1.5); }
-}
-
-/* Detail panel — consistent with AgentGraphView */
-.detail-panel {
-  position: absolute;
-  top: 0;
-  right: 0;
-  width: 300px;
-  height: 100%;
-  background: #1e293b;
-  border-left: 1px solid #4b5563;
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  box-shadow: -4px 0 24px rgba(0, 0, 0, 0.4);
-  z-index: 10;
 }
 
-.detail-header {
+.tree-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 12px;
+  flex-shrink: 0;
+}
+
+.tree-header h3 {
+  margin: 0;
+  font-size: 14px;
+  color: #e5e7eb;
+}
+
+.toggle-completed {
+  font-size: 11px;
+  color: #94a3b8;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+}
+
+.tree-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0 8px 12px;
+}
+
+/* Node indentation per level */
+.goal-node {
+  padding-left: 0;
+}
+
+.idea-node {
+  padding-left: 20px;
+}
+
+.plan-node {
+  padding-left: 40px;
+}
+
+.task-node {
+  padding-left: 60px;
+}
+
+.node-header {
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 12px 14px;
-  border-bottom: 1px solid #4b5563;
-  flex-shrink: 0;
+  padding: 6px 8px;
+  cursor: pointer;
+  border-radius: 4px;
 }
 
-.detail-type-badge {
+.node-header:hover {
+  background: #1e293b;
+}
+
+.expand-icon {
+  width: 16px;
+  color: #6b7280;
   font-size: 10px;
-  padding: 2px 8px;
-  border-radius: 10px;
-  font-weight: 600;
-  text-transform: uppercase;
+  flex-shrink: 0;
+  text-align: center;
+}
+
+.node-icon {
+  font-size: 14px;
   flex-shrink: 0;
 }
 
-.detail-type-badge.goal {
-  background: rgba(234, 179, 8, 0.2);
-  color: #eab308;
-}
-
-.detail-type-badge.idea {
-  background: rgba(168, 85, 247, 0.2);
-  color: #a855f7;
-}
-
-.detail-type-badge.plan {
-  background: rgba(59, 130, 246, 0.2);
-  color: #3b82f6;
-}
-
-.detail-title {
-  font-size: 14px;
-  font-weight: 600;
+.node-title {
   color: #e5e7eb;
+  font-size: 13px;
   flex: 1;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.detail-close {
-  background: none;
-  border: none;
-  color: #9ca3af;
-  font-size: 20px;
-  cursor: pointer;
-  padding: 0 4px;
-  line-height: 1;
+.node-title.done {
+  text-decoration: line-through;
+  color: #6b7280;
+}
+
+.node-badge {
+  font-size: 10px;
+  padding: 1px 6px;
+  border-radius: 8px;
   flex-shrink: 0;
 }
 
-.detail-close:hover {
-  color: #f3f4f6;
+.node-badge.active {
+  background: #7c3aed33;
+  color: #a78bfa;
 }
 
-.detail-body {
-  overflow-y: auto;
-  padding: 12px 14px;
-  flex: 1;
-}
-
-.detail-meta-row {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 6px 0;
-  border-bottom: 1px solid #374151;
-}
-
-.detail-meta-label {
-  font-size: 11px;
-  color: #9ca3af;
-}
-
-.detail-meta-value {
-  font-size: 12px;
-  color: #d1d5db;
-  font-weight: 600;
-}
-
-.detail-meta-status {
-  font-size: 10px;
-  padding: 2px 8px;
-  border-radius: 10px;
-  font-weight: 600;
-}
-
-.detail-meta-status.pending {
-  background: rgba(107, 114, 128, 0.2);
-  color: #9ca3af;
-}
-
-.detail-meta-status.approved {
-  background: rgba(59, 130, 246, 0.2);
-  color: #3b82f6;
-}
-
-.detail-meta-status.in_progress {
-  background: rgba(34, 197, 94, 0.2);
+.node-badge.approved {
+  background: #22c55e33;
   color: #22c55e;
 }
 
-.detail-meta-status.done {
-  background: rgba(34, 197, 94, 0.2);
-  color: #22c55e;
+.node-badge.pending {
+  background: #eab30833;
+  color: #eab308;
 }
 
-.detail-meta-status.rejected {
-  background: rgba(239, 68, 68, 0.2);
+.node-badge.done,
+.node-badge.completed {
+  background: #6b728033;
+  color: #6b7280;
+}
+
+.node-badge.rejected {
+  background: #ef444433;
   color: #ef4444;
 }
 
-.detail-meta-status.boundary {
-  background: rgba(245, 158, 11, 0.2);
-  color: #f59e0b;
+.node-badge.superseded {
+  background: #6b728033;
+  color: #6b7280;
 }
 
-.detail-section {
-  margin-top: 14px;
-}
-
-.detail-section-title {
-  font-size: 11px;
-  font-weight: 600;
-  color: #9ca3af;
-  text-transform: uppercase;
-  margin-bottom: 8px;
-}
-
-.detail-description {
-  font-size: 13px;
-  color: #d1d5db;
-  line-height: 1.5;
-  white-space: pre-wrap;
-  word-break: break-word;
-}
-
-.dialogue-turn {
-  margin-bottom: 10px;
-  padding: 8px;
-  border-radius: 6px;
-  background: #111827;
-  border-left: 3px solid #4b5563;
-}
-
-.dialogue-turn.boundary {
-  border-left-color: #f59e0b;
-}
-
-.dialogue-turn.verdict {
-  border-left-color: #3b82f6;
-}
-
-.turn-meta {
-  display: flex;
-  gap: 6px;
-  align-items: center;
-  margin-bottom: 4px;
-}
-
-.turn-agent {
-  font-size: 11px;
-  font-weight: 600;
-  color: #9ca3af;
-}
-
-.turn-verdict {
+.verdict-badge {
   font-size: 10px;
   padding: 1px 6px;
-  border-radius: 3px;
-  font-weight: 600;
+  border-radius: 8px;
+  flex-shrink: 0;
 }
 
-.turn-verdict.approved {
-  background: rgba(34, 197, 94, 0.2);
+.verdict-badge.approved {
+  background: #22c55e33;
   color: #22c55e;
 }
 
-.turn-verdict.rejected {
-  background: rgba(239, 68, 68, 0.2);
+.verdict-badge.pending {
+  background: #eab30833;
+  color: #eab308;
+}
+
+.verdict-badge.rejected {
+  background: #ef444433;
   color: #ef4444;
 }
 
-.turn-verdict.rework {
-  background: rgba(245, 158, 11, 0.2);
+.verdict-badge.boundary {
+  background: #f59e0b33;
   color: #f59e0b;
 }
 
-.turn-boundary {
-  font-size: 10px;
-  padding: 1px 6px;
-  border-radius: 3px;
-  background: rgba(245, 158, 11, 0.15);
-  color: #f59e0b;
+.verdict-badge.rework {
+  background: #eab30833;
+  color: #eab308;
 }
 
-.turn-text {
-  font-size: 12px;
-  color: #d1d5db;
+.node-detail {
+  font-size: 11px;
+  color: #94a3b8;
+  padding: 4px 8px 4px 44px;
   line-height: 1.4;
 }
 
-.turn-argument {
-  font-style: italic;
-  color: #9ca3af;
-  margin-top: 2px;
-}
-
-.dialogue-empty {
-  color: #6b7280;
-  font-size: 12px;
-  text-align: center;
-  padding: 20px 0;
-}
-
-.tasks-section {
-  margin-top: 12px;
-  padding-top: 10px;
-  border-top: 1px solid #374151;
-}
-
-.tasks-title {
-  font-size: 11px;
+.detail-label {
   font-weight: 600;
-  color: #9ca3af;
-  margin-bottom: 6px;
-  text-transform: uppercase;
-}
-
-.task-item {
-  font-size: 12px;
-  color: #d1d5db;
-  padding: 3px 0;
-  display: flex;
-  align-items: center;
-  gap: 6px;
-}
-
-.task-item.done {
-  color: #22c55e;
-  text-decoration: line-through;
-  opacity: 0.7;
 }
 
 .task-check {
-  font-size: 11px;
-  width: 14px;
+  font-size: 12px;
   flex-shrink: 0;
 }
 
-/* Transition */
-.panel-slide-enter-active,
-.panel-slide-leave-active {
-  transition: transform 0.2s ease, opacity 0.2s ease;
+.tree-section {
+  margin-top: 12px;
 }
 
-.panel-slide-enter-from,
-.panel-slide-leave-to {
-  transform: translateX(20px);
-  opacity: 0;
+.section-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: #6b7280;
+  text-transform: uppercase;
+  padding: 4px 8px;
+}
+
+.empty {
+  color: #6b7280;
+  padding: 20px;
+  text-align: center;
+  font-size: 13px;
 }
 </style>

--- a/dashboard/src/modules/soul/SoulApiClient.ts
+++ b/dashboard/src/modules/soul/SoulApiClient.ts
@@ -47,3 +47,88 @@ export function connectActivityStream(onEvent: (event: ActivityEvent) => void): 
   es.onerror = () => { /* auto-reconnects */ };
   return () => es.close();
 }
+
+// ── Chat Threads ────────────────────────────────────────────────────────────
+
+export interface ChatThread {
+  id: string;
+  title: string;
+  pending: boolean;
+  lastMessage?: { role: string; text: string; ts: number };
+  messageCount: number;
+}
+
+export interface ChatMessage {
+  role: 'user' | 'agent';
+  text: string;
+  agentId?: string;
+  ts: number;
+}
+
+export async function fetchThreads(): Promise<ChatThread[]> {
+  const res = await fetch('/api/chat/threads');
+  if (!res.ok) return [];
+  return res.json();
+}
+
+export async function fetchMessages(threadId: string): Promise<ChatMessage[]> {
+  const res = await fetch(`/api/chat/threads/${threadId}/messages`);
+  if (!res.ok) return [];
+  return res.json();
+}
+
+export async function sendMessage(threadId: string, text: string): Promise<string> {
+  const res = await fetch(`/api/chat/threads/${threadId}/messages`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ text }),
+  });
+  if (!res.ok) return '';
+  const data = await res.json();
+  return data.reply ?? '';
+}
+
+export async function createThread(title: string): Promise<ChatThread | null> {
+  const res = await fetch('/api/chat/threads', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ title }),
+  });
+  if (!res.ok) return null;
+  return res.json();
+}
+
+// ── Agent Activity Stream ───────────────────────────────────────────────────
+
+export interface AgentActivityEvent {
+  type: 'tool_call' | 'thinking' | 'text' | 'signal';
+  summary: string;
+  detail?: string;
+  toolName?: string;
+  timestamp: number;
+}
+
+export function connectAgentStream(agentId: string, onEvent: (e: AgentActivityEvent) => void): () => void {
+  const es = new EventSource(`/api/agents/${agentId}/stream`);
+  es.onmessage = (e) => {
+    try {
+      onEvent(JSON.parse(e.data));
+    } catch { /* ignore */ }
+  };
+  es.onerror = () => { /* auto-reconnects */ };
+  return () => es.close();
+}
+
+// ── Journal ─────────────────────────────────────────────────────────────────
+
+export interface JournalEntry {
+  timestamp: string;
+  agent: string;
+  text: string;
+}
+
+export async function fetchJournal(): Promise<JournalEntry[]> {
+  const res = await fetch('/api/soul/journal');
+  if (!res.ok) return [];
+  return res.json();
+}

--- a/dashboard/src/modules/soul/SoulApiClient.ts
+++ b/dashboard/src/modules/soul/SoulApiClient.ts
@@ -14,6 +14,19 @@ export interface ActivityEvent {
   from?: string; to?: string; subtype?: string; timestamp: number;
 }
 
+export interface AgentTopologyNode {
+  id: string; name: string; description: string; icon: string; status: string;
+  subscribe_topics: string[]; outputs: Array<{ port: string; subject: string }>;
+}
+export interface AgentTopologyEdge { from: string; to: string; subject: string; port: string; }
+export interface AgentTopology { agents: AgentTopologyNode[]; edges: AgentTopologyEdge[]; }
+
+export async function fetchAgentTopology(): Promise<AgentTopology> {
+  const res = await fetch('/api/agents/topology');
+  if (!res.ok) return { agents: [], edges: [] };
+  return res.json();
+}
+
 export async function fetchSoulState(filters?: { status?: string }): Promise<SoulState> {
   const params = new URLSearchParams();
   if (filters?.status) params.set('status', filters.status);

--- a/dashboard/src/modules/soul/SoulApiClient.ts
+++ b/dashboard/src/modules/soul/SoulApiClient.ts
@@ -109,7 +109,7 @@ export interface AgentActivityEvent {
 }
 
 export function connectAgentStream(agentId: string, onEvent: (e: AgentActivityEvent) => void): () => void {
-  const es = new EventSource(`/api/agents/${agentId}/stream`);
+  const es = new EventSource(`/api/agents/${encodeURIComponent(agentId)}/stream`);
   es.onmessage = (e) => {
     try {
       onEvent(JSON.parse(e.data));

--- a/dashboard/src/modules/soul/SoulView.vue
+++ b/dashboard/src/modules/soul/SoulView.vue
@@ -1,50 +1,34 @@
 <template>
   <div class="soul-view">
-    <div class="soul-header">
-      <h2>🧠 Thinking</h2>
-      <div class="view-switcher">
-        <button :class="{ active: view === 'split' }" @click="view = 'split'">Split</button>
-        <button :class="{ active: view === 'mindmap' }" @click="view = 'mindmap'">Mind Map</button>
-        <button :class="{ active: view === 'agents' }" @click="view = 'agents'">Agents</button>
-      </div>
+    <!-- View switcher (top-right) -->
+    <div class="view-switcher">
+      <button :class="{ active: view === 'graph' }" @click="view = 'graph'">Graf</button>
+      <button :class="{ active: view === 'map' }" @click="view = 'map'">Mapa</button>
     </div>
-    <div class="soul-main">
-      <div class="soul-content" :class="view">
-        <MindMapView
-          v-if="view === 'split' || view === 'mindmap'"
-          :state="soulState"
-          :activity="recentActivity"
-          class="panel"
-        />
-        <AgentGraphView
-          v-if="view === 'split' || view === 'agents'"
-          :activity="recentActivity"
-          class="panel"
-        />
-      </div>
-      <div class="journal-panel">
-        <div class="journal-header">
-          <span class="journal-title">💭 Thought Journal</span>
-          <span class="journal-count">{{ journal.length }}</span>
-        </div>
-        <div class="journal-entries">
-          <div v-if="journal.length === 0" class="journal-empty">
-            No thoughts yet...
-          </div>
-          <div
-            v-for="(entry, idx) in journal"
-            :key="idx"
-            class="journal-entry"
-          >
-            <div class="entry-meta">
-              <span class="entry-agent">{{ entry.agent }}</span>
-              <span class="entry-time">{{ formatTime(entry.timestamp) }}</span>
-            </div>
-            <div class="entry-text">{{ entry.text }}</div>
-          </div>
-        </div>
-      </div>
-    </div>
+
+    <!-- Main area: Graph or Mind Map (fullscreen) -->
+    <AgentGraphView
+      v-if="view === 'graph'"
+      :activity="recentActivity"
+      @select-agent="selectedAgent = $event"
+      class="main-view"
+    />
+    <MindMapView
+      v-else
+      :state="soulState"
+      :activity="recentActivity"
+      class="main-view"
+    />
+
+    <!-- Agent Detail Panel (left slide) -->
+    <AgentDetailPanel
+      v-if="selectedAgent"
+      :agentId="selectedAgent"
+      @close="selectedAgent = null"
+    />
+
+    <!-- Chat Panel (floating bottom-right) -->
+    <ChatPanel />
   </div>
 </template>
 
@@ -52,43 +36,24 @@
 import { ref, onMounted, onUnmounted } from 'vue';
 import MindMapView from './MindMapView.vue';
 import AgentGraphView from './AgentGraphView.vue';
+import AgentDetailPanel from './AgentDetailPanel.vue';
+import ChatPanel from './ChatPanel.vue';
 import { fetchSoulState, connectActivityStream, type SoulState, type ActivityEvent } from './SoulApiClient';
 
-interface JournalEntry {
-  timestamp: string;
-  agent: string;
-  text: string;
-}
-
-const view = ref<'split' | 'mindmap' | 'agents'>('split');
+const view = ref<'graph' | 'map'>('graph');
 const soulState = ref<SoulState>({ goals: [], orphanIdeas: [], orphanPlans: [] });
 const recentActivity = ref<ActivityEvent[]>([]);
-const journal = ref<JournalEntry[]>([]);
+const selectedAgent = ref<string | null>(null);
 const MAX_ACTIVITY = 200;
 
 let stopStream: (() => void) | null = null;
 let pollInterval: ReturnType<typeof setInterval> | null = null;
 
-async function fetchJournal() {
-  try {
-    const res = await fetch('/api/soul/journal');
-    if (res.ok) journal.value = await res.json();
-  } catch { /* ignore */ }
-}
-
-function formatTime(ts: string): string {
-  // ts format: "2026-03-24T10:28:16"
-  const timePart = ts.includes('T') ? ts.split('T')[1] : ts;
-  return timePart.slice(0, 8);
-}
-
 onMounted(async () => {
   soulState.value = await fetchSoulState();
-  await fetchJournal();
 
   pollInterval = setInterval(async () => {
     soulState.value = await fetchSoulState();
-    await fetchJournal();
   }, 5000);
 
   stopStream = connectActivityStream((event) => {
@@ -103,96 +68,49 @@ onUnmounted(() => {
 </script>
 
 <style scoped>
-.soul-view { display: flex; flex-direction: column; height: 100%; }
-.soul-header { display: flex; justify-content: space-between; align-items: center; padding: 12px 16px; border-bottom: 1px solid var(--border-color, #333); }
-.soul-header h2 { margin: 0; font-size: 18px; }
-.view-switcher { display: flex; gap: 4px; }
-.view-switcher button { padding: 4px 12px; border: 1px solid var(--border-color, #333); background: transparent; color: inherit; border-radius: 4px; cursor: pointer; }
-.view-switcher button.active { background: var(--accent-color, #7c3aed); border-color: var(--accent-color, #7c3aed); }
+.soul-view {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  background: #0f172a;
+}
 
-.soul-main { flex: 1; display: flex; flex-direction: column; overflow: hidden; }
-.soul-content { flex: 1; display: flex; overflow: hidden; min-height: 0; }
-.soul-content.split .panel { flex: 1; }
-.soul-content.mindmap .panel, .soul-content.agents .panel { flex: 1; }
-.panel { min-width: 0; }
+.main-view {
+  width: 100%;
+  height: 100%;
+}
 
-.journal-panel {
-  height: 220px;
-  min-height: 180px;
-  border-top: 1px solid #374151;
+.view-switcher {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  z-index: 20;
   display: flex;
-  flex-direction: column;
-  background: #111827;
-}
-
-.journal-header {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 8px 16px;
-  border-bottom: 1px solid #1f2937;
-}
-
-.journal-title {
-  font-size: 13px;
-  font-weight: 600;
-  color: #c4b5fd;
-}
-
-.journal-count {
-  font-size: 11px;
-  color: #6b7280;
-  background: #1f2937;
-  padding: 1px 6px;
-  border-radius: 8px;
-}
-
-.journal-entries {
-  flex: 1;
-  overflow-y: auto;
-  padding: 8px 16px;
-}
-
-.journal-empty {
-  color: #6b7280;
-  font-size: 13px;
-  padding: 16px 0;
-  text-align: center;
-}
-
-.journal-entry {
-  margin-bottom: 12px;
-  padding: 8px 10px;
+  gap: 2px;
   background: #1e293b;
+  border: 1px solid #334155;
   border-radius: 6px;
-  border-left: 3px solid #7c3aed;
+  padding: 2px;
 }
 
-.entry-meta {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 4px;
-}
-
-.entry-agent {
-  font-size: 11px;
-  font-weight: 600;
-  color: #a78bfa;
-  text-transform: uppercase;
-}
-
-.entry-time {
-  font-size: 11px;
-  color: #6b7280;
-  font-family: monospace;
-}
-
-.entry-text {
+.view-switcher button {
+  padding: 4px 12px;
+  border: none;
+  background: transparent;
+  color: #94a3b8;
+  border-radius: 4px;
+  cursor: pointer;
   font-size: 12px;
-  color: #d1d5db;
-  line-height: 1.5;
-  white-space: pre-wrap;
-  word-break: break-word;
+  font-weight: 500;
+}
+
+.view-switcher button.active {
+  background: #7c3aed;
+  color: #f3f4f6;
+}
+
+.view-switcher button:hover:not(.active) {
+  background: #334155;
 }
 </style>

--- a/features/settings/feature.json
+++ b/features/settings/feature.json
@@ -18,6 +18,11 @@
         "path": "/settings",
         "component": "SettingsView",
         "nav": { "label": "Settings", "icon": "⚙️" }
+      },
+      {
+        "path": "/secrets",
+        "component": "SecretsView",
+        "nav": { "label": "Secrets", "icon": "🔐" }
       }
     ]
   }

--- a/features/settings/frontend/src/SecretsView.vue
+++ b/features/settings/frontend/src/SecretsView.vue
@@ -1,0 +1,539 @@
+<template>
+  <div class="secrets-view">
+    <div class="secrets-header">
+      <h1>Secrets</h1>
+    </div>
+
+    <div class="secrets-body">
+      <!-- Warning banner -->
+      <div class="warning-banner">
+        LLM agents never receive secret values. Secrets are injected as environment variables into agent containers at startup.
+      </div>
+
+      <!-- Add Secret -->
+      <div class="secrets-section">
+        <div class="section-title-row">
+          <h2>Stored Secrets</h2>
+          <button class="btn-primary" @click="openAddForm">+ Add Secret</button>
+        </div>
+
+        <!-- Add / Edit form -->
+        <div v-if="showForm" class="secret-form">
+          <div class="field-row">
+            <label class="field-label">Key</label>
+            <input
+              v-model="formKey"
+              type="text"
+              placeholder="e.g. GH_TOKEN, SLACK_WEBHOOK_URL"
+              class="field-input"
+              :disabled="formMode === 'edit'"
+            />
+          </div>
+          <div class="field-row">
+            <label class="field-label">Value</label>
+            <input
+              v-model="formValue"
+              type="password"
+              placeholder="Secret value..."
+              class="field-input"
+            />
+          </div>
+          <div class="form-actions">
+            <button
+              class="btn-primary"
+              :disabled="!formKey.trim() || !formValue.trim() || formSaving"
+              @click="saveSecret"
+            >{{ formSaving ? 'Saving...' : formMode === 'edit' ? 'Update Secret' : 'Save Secret' }}</button>
+            <button class="btn-secondary" @click="closeForm">Cancel</button>
+          </div>
+          <div v-if="formError" class="error-msg">{{ formError }}</div>
+        </div>
+
+        <!-- Secrets table -->
+        <div v-if="loading" class="loading">Loading secrets...</div>
+        <div v-else-if="loadError" class="error-msg">{{ loadError }}</div>
+        <div v-else-if="secrets.length === 0 && !showForm" class="empty-state">
+          No secrets stored yet. Click "Add Secret" to create one.
+        </div>
+        <table v-else-if="secrets.length > 0" class="secrets-table">
+          <thead>
+            <tr>
+              <th>Key</th>
+              <th>Status</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="secret in secrets" :key="secret.key">
+              <td class="key-cell"><code>{{ secret.key }}</code></td>
+              <td>
+                <span v-if="secret.set" class="status-set">Set</span>
+                <span v-else class="status-missing">Missing</span>
+              </td>
+              <td class="actions-cell">
+                <button class="btn-action" @click="editSecret(secret.key)">Edit</button>
+                <button class="btn-action btn-danger" @click="confirmDelete(secret.key)">Delete</button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <!-- Required by agents -->
+      <div v-if="Object.keys(required).length > 0" class="secrets-section">
+        <h2>Required by Agents</h2>
+        <div v-for="(keys, agentId) in required" :key="agentId" class="agent-req">
+          <div class="agent-name">{{ agentId }}</div>
+          <div class="agent-keys">
+            <span
+              v-for="k in keys"
+              :key="k"
+              :class="['req-key', isSecretSet(k) ? 'req-set' : 'req-missing']"
+            >
+              {{ k }}
+              <span v-if="isSecretSet(k)" class="req-icon">&#x2705;</span>
+              <span v-else class="req-icon">&#x274C;</span>
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Delete confirmation modal -->
+    <div v-if="deleteKey" class="modal-overlay" @click.self="deleteKey = null">
+      <div class="modal-box">
+        <h3>Delete Secret</h3>
+        <p>Are you sure you want to delete <code>{{ deleteKey }}</code>? This action cannot be undone.</p>
+        <div class="modal-actions">
+          <button class="btn-secondary" @click="deleteKey = null">Cancel</button>
+          <button class="btn-primary btn-delete" :disabled="deleting" @click="doDelete">
+            {{ deleting ? 'Deleting...' : 'Delete' }}
+          </button>
+        </div>
+        <div v-if="deleteError" class="error-msg">{{ deleteError }}</div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+
+interface SecretEntry { key: string; set: boolean }
+
+const secrets = ref<SecretEntry[]>([])
+const required = ref<Record<string, string[]>>({})
+const loading = ref(true)
+const loadError = ref('')
+
+// Form state
+const showForm = ref(false)
+const formMode = ref<'add' | 'edit'>('add')
+const formKey = ref('')
+const formValue = ref('')
+const formSaving = ref(false)
+const formError = ref('')
+
+// Delete state
+const deleteKey = ref<string | null>(null)
+const deleting = ref(false)
+const deleteError = ref('')
+
+function isSecretSet(key: string): boolean {
+  return secrets.value.some(s => s.key === key && s.set)
+}
+
+async function loadSecrets() {
+  loading.value = true
+  loadError.value = ''
+  try {
+    const res = await fetch('/api/secrets')
+    if (!res.ok) throw new Error(`HTTP ${res.status}`)
+    const data = await res.json() as { secrets: SecretEntry[]; required: Record<string, string[]> }
+    secrets.value = data.secrets ?? []
+    required.value = data.required ?? {}
+  } catch (e: unknown) {
+    loadError.value = `Failed to load secrets: ${e instanceof Error ? e.message : String(e)}`
+  } finally {
+    loading.value = false
+  }
+}
+
+function openAddForm() {
+  formMode.value = 'add'
+  formKey.value = ''
+  formValue.value = ''
+  formError.value = ''
+  showForm.value = true
+}
+
+function editSecret(key: string) {
+  formMode.value = 'edit'
+  formKey.value = key
+  formValue.value = ''
+  formError.value = ''
+  showForm.value = true
+}
+
+function closeForm() {
+  showForm.value = false
+  formKey.value = ''
+  formValue.value = ''
+  formError.value = ''
+}
+
+async function saveSecret() {
+  formSaving.value = true
+  formError.value = ''
+  try {
+    const res = await fetch('/api/secrets', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ key: formKey.value.trim(), value: formValue.value }),
+    })
+    if (!res.ok) {
+      const body = await res.text()
+      throw new Error(body || `HTTP ${res.status}`)
+    }
+    closeForm()
+    await loadSecrets()
+  } catch (e: unknown) {
+    formError.value = `Failed to save: ${e instanceof Error ? e.message : String(e)}`
+  } finally {
+    formSaving.value = false
+  }
+}
+
+function confirmDelete(key: string) {
+  deleteKey.value = key
+  deleteError.value = ''
+}
+
+async function doDelete() {
+  if (!deleteKey.value) return
+  deleting.value = true
+  deleteError.value = ''
+  try {
+    const res = await fetch(`/api/secrets/${encodeURIComponent(deleteKey.value)}`, {
+      method: 'DELETE',
+    })
+    if (!res.ok) {
+      const body = await res.text()
+      throw new Error(body || `HTTP ${res.status}`)
+    }
+    deleteKey.value = null
+    await loadSecrets()
+  } catch (e: unknown) {
+    deleteError.value = `Failed to delete: ${e instanceof Error ? e.message : String(e)}`
+  } finally {
+    deleting.value = false
+  }
+}
+
+onMounted(loadSecrets)
+</script>
+
+<style scoped>
+.secrets-view {
+  padding: 24px;
+  max-width: 720px;
+  margin: 0 auto;
+  color: var(--text, #e6edf3);
+}
+
+.secrets-header h1 {
+  font-size: 20px;
+  font-weight: 700;
+  margin: 0 0 12px;
+}
+
+.secrets-body {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.warning-banner {
+  background: rgba(210, 153, 34, 0.08);
+  border: 1px solid rgba(210, 153, 34, 0.3);
+  border-radius: 6px;
+  padding: 10px 14px;
+  font-size: 13px;
+  color: #d29922;
+}
+
+.secrets-section {
+  background: var(--surface, #161b22);
+  border: 1px solid var(--border, #30363d);
+  border-radius: 8px;
+  padding: 20px;
+}
+
+.secrets-section h2 {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-muted, #8b949e);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin: 0 0 16px;
+}
+
+.section-title-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+}
+.section-title-row h2 {
+  margin: 0;
+}
+
+.loading { font-size: 13px; color: var(--text-muted, #8b949e); }
+.error-msg { color: var(--danger, #f85149); font-size: 13px; margin: 8px 0; }
+
+.empty-state {
+  font-size: 13px;
+  color: var(--text-muted, #8b949e);
+  padding: 16px 0;
+}
+
+/* Form */
+.secret-form {
+  background: var(--bg, #0d1117);
+  border: 1px solid var(--border, #30363d);
+  border-radius: 6px;
+  padding: 16px;
+  margin-bottom: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.field-row {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.field-label {
+  font-size: 12px;
+  color: var(--text-muted, #8b949e);
+  font-weight: 600;
+}
+
+.field-input {
+  padding: 8px 12px;
+  background: var(--surface, #161b22);
+  border: 1px solid var(--border, #30363d);
+  border-radius: 6px;
+  color: var(--text, #e6edf3);
+  font-size: 13px;
+  outline: none;
+}
+.field-input:focus { border-color: var(--accent, #58a6ff); }
+.field-input:disabled { opacity: 0.5; }
+
+.form-actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+/* Table */
+.secrets-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.secrets-table th {
+  text-align: left;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-muted, #8b949e);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border, #30363d);
+}
+
+.secrets-table td {
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border, #30363d);
+}
+
+.secrets-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.secrets-table tbody tr:hover {
+  background: var(--surface2, #1c2128);
+}
+
+.key-cell code {
+  font-size: 13px;
+  background: var(--surface2, #1c2128);
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.status-set {
+  font-size: 12px;
+  background: rgba(63, 185, 80, 0.1);
+  color: var(--accent2, #3fb950);
+  padding: 2px 8px;
+  border-radius: 4px;
+}
+
+.status-missing {
+  font-size: 12px;
+  background: rgba(248, 81, 73, 0.1);
+  color: var(--danger, #f85149);
+  padding: 2px 8px;
+  border-radius: 4px;
+}
+
+.actions-cell {
+  display: flex;
+  gap: 6px;
+}
+
+.btn-action {
+  padding: 4px 10px;
+  background: none;
+  border: 1px solid var(--border, #30363d);
+  border-radius: 6px;
+  color: var(--text, #e6edf3);
+  cursor: pointer;
+  font-size: 12px;
+}
+.btn-action:hover { background: var(--surface2, #1c2128); }
+
+.btn-danger {
+  border-color: rgba(248, 81, 73, 0.4);
+  color: var(--danger, #f85149);
+}
+.btn-danger:hover { background: rgba(248, 81, 73, 0.1); }
+
+.btn-primary {
+  padding: 8px 20px;
+  background: var(--accent, #58a6ff);
+  color: #0d1117;
+  border: none;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.btn-primary:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.btn-secondary {
+  padding: 6px 14px;
+  background: var(--surface2, #1c2128);
+  color: var(--text, #e6edf3);
+  border: 1px solid var(--border, #30363d);
+  border-radius: 6px;
+  font-size: 13px;
+  cursor: pointer;
+}
+.btn-secondary:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.btn-delete {
+  background: var(--danger, #f85149);
+  color: #fff;
+}
+.btn-delete:hover { background: #da3633; }
+
+/* Required by agents */
+.agent-req {
+  border: 1px solid var(--border, #30363d);
+  border-radius: 6px;
+  padding: 12px 16px;
+  margin-bottom: 8px;
+}
+.agent-req:last-child { margin-bottom: 0; }
+
+.agent-name {
+  font-size: 14px;
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+
+.agent-keys {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.req-key {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+  padding: 3px 8px;
+  border-radius: 4px;
+  font-family: monospace;
+}
+
+.req-set {
+  background: rgba(63, 185, 80, 0.1);
+  color: var(--accent2, #3fb950);
+}
+
+.req-missing {
+  background: rgba(248, 81, 73, 0.1);
+  color: var(--danger, #f85149);
+}
+
+.req-icon {
+  font-size: 11px;
+}
+
+/* Delete modal */
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal-box {
+  background: var(--surface, #161b22);
+  border: 1px solid var(--border, #30363d);
+  border-radius: 8px;
+  padding: 24px;
+  max-width: 420px;
+  width: 90%;
+}
+
+.modal-box h3 {
+  margin: 0 0 12px;
+  font-size: 16px;
+}
+
+.modal-box p {
+  font-size: 13px;
+  color: var(--text-muted, #8b949e);
+  margin: 0 0 16px;
+}
+
+.modal-box code {
+  background: var(--surface2, #1c2128);
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 13px;
+  color: var(--text, #e6edf3);
+}
+
+.modal-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+</style>

--- a/features/settings/frontend/src/entry.ts
+++ b/features/settings/frontend/src/entry.ts
@@ -1,2 +1,3 @@
 export { default as SetupWizard } from './SetupWizard.vue'
 export { default as SettingsView } from './SettingsView.vue'
+export { default as SecretsView } from './SecretsView.vue'

--- a/features/settings/frontend/vite.config.ts
+++ b/features/settings/frontend/vite.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
       exposes: {
         './SetupWizard': './src/SetupWizard.vue',
         './SettingsView': './src/SettingsView.vue',
+        './SecretsView': './src/SecretsView.vue',
       },
       shared: {
         vue: { singleton: true, requiredVersion: '^3.4.0' },

--- a/features/settings/tool.json
+++ b/features/settings/tool.json
@@ -18,6 +18,11 @@
         "path": "/settings",
         "component": "SettingsView",
         "nav": { "label": "Settings", "icon": "⚙️" }
+      },
+      {
+        "path": "/secrets",
+        "component": "SecretsView",
+        "nav": { "label": "Secrets", "icon": "🔐" }
       }
     ]
   }

--- a/features/simple-chat/plugin.mjs
+++ b/features/simple-chat/plugin.mjs
@@ -21,18 +21,12 @@ export default {
     const { publishNats } = opts;
 
     // ── POST /api/chat/simple-chat ────────────────────────────────────────────
-    // agentId in body overrides default; fallback: first running stateful agent or 'foreman'
+    // agentId in body overrides default; fallback: chat-agent (always present in BASE_AGENTS)
     app.post('/api/chat/simple-chat', async (req, res) => {
       const { message, sessionId, agentId: bodyAgentId } = req.body ?? {};
       if (!message) return res.status(400).json({ error: '"message" required' });
 
-      // Resolve target agent: explicit > first running inbox agent > foreman
-      let targetAgent = bodyAgentId;
-      if (!targetAgent) {
-        const states = _manager.getStates?.() ?? [];
-        const running = states.find(s => s.status === 'running');
-        targetAgent = running?.agentId ?? 'foreman';
-      }
+      const targetAgent = bodyAgentId ?? 'chat-agent';
 
       const sid = sessionId ?? 'default';
       const streamSubject = `chat.stream.${sid}.${Date.now()}`;

--- a/src/activity-emitter.ts
+++ b/src/activity-emitter.ts
@@ -6,7 +6,7 @@ const sc = StringCodec();
 
 export interface ActivityEvent {
   agent: string;
-  type: 'thinking' | 'dialogue' | 'idea' | 'plan' | 'action' | 'user';
+  type: 'thinking' | 'dialogue' | 'idea' | 'plan' | 'action' | 'user' | 'reflect';
   entityId?: string;
   summary: string;
   from?: string;

--- a/src/agent-manager.ts
+++ b/src/agent-manager.ts
@@ -1251,6 +1251,12 @@ export class AgentManager {
     fs.mkdirSync(obsidianDir, { recursive: true });
     binds.push(`${obsidianDir}:/obsidian:rw`);
 
+    // Volume: ARCHITECTURE.md → /workspace/agent/ARCHITECTURE.md (system knowledge for all agents)
+    const archFile = path.join(hostDataDir, 'ARCHITECTURE.md');
+    if (fs.existsSync(archFile)) {
+      binds.push(`${archFile}:/workspace/agent/ARCHITECTURE.md:ro`);
+    }
+
     // Volume: project root → /workspace/repo (for self-dev agents that edit the project itself)
     if (agent.manifest.project_workspace && !agent.manifest.repo_path) {
       const projectRoot = path.resolve(hostDataDir, '..', '..');

--- a/src/agent-manager.ts
+++ b/src/agent-manager.ts
@@ -1049,8 +1049,13 @@ export class AgentManager {
     }
 
     // Read shards referenced in manifest
+    const SAFE_SHARD = /^[a-zA-Z0-9_-]+$/;
     const shards = agent.manifest.shards ?? [];
     for (const shard of shards) {
+      if (!SAFE_SHARD.test(shard)) {
+        logger.warn({ agentId, shard }, 'Shard name contains invalid characters — skipping');
+        continue;
+      }
       const shardPath = path.join(hubDir, 'shards', `${shard}.md`);
       if (fs.existsSync(shardPath)) {
         policyPrefix += fs.readFileSync(shardPath, 'utf8') + '\n\n';
@@ -1278,12 +1283,7 @@ export class AgentManager {
     fs.mkdirSync(path.join(obsidianDir, 'Consciousness', 'agents'), { recursive: true });
     binds.push(`${obsidianDir}:/obsidian:rw`);
 
-    // Volume: ARCHITECTURE.md → /workspace/ARCHITECTURE.md (system knowledge for all agents)
-    // Mounted at /workspace/ (writable layer) not /workspace/agent/ (read-only COPY layer)
-    const archFile = path.join(hostDataDir, 'ARCHITECTURE.md');
-    if (fs.existsSync(archFile)) {
-      binds.push(`${archFile}:/workspace/ARCHITECTURE.md:ro`);
-    }
+    // ARCHITECTURE.md removed — now delivered via shards/architecture.md in system prompt
 
     // Volume: project root → /workspace/repo (for self-dev agents that edit the project itself)
     if (agent.manifest.project_workspace && !agent.manifest.repo_path) {

--- a/src/agent-manager.ts
+++ b/src/agent-manager.ts
@@ -1251,10 +1251,11 @@ export class AgentManager {
     fs.mkdirSync(obsidianDir, { recursive: true });
     binds.push(`${obsidianDir}:/obsidian:rw`);
 
-    // Volume: ARCHITECTURE.md → /workspace/agent/ARCHITECTURE.md (system knowledge for all agents)
+    // Volume: ARCHITECTURE.md → /workspace/ARCHITECTURE.md (system knowledge for all agents)
+    // Mounted at /workspace/ (writable layer) not /workspace/agent/ (read-only COPY layer)
     const archFile = path.join(hostDataDir, 'ARCHITECTURE.md');
     if (fs.existsSync(archFile)) {
-      binds.push(`${archFile}:/workspace/agent/ARCHITECTURE.md:ro`);
+      binds.push(`${archFile}:/workspace/ARCHITECTURE.md:ro`);
     }
 
     // Volume: project root → /workspace/repo (for self-dev agents that edit the project itself)

--- a/src/agent-manager.ts
+++ b/src/agent-manager.ts
@@ -1274,6 +1274,8 @@ export class AgentManager {
     // Volume: instance Obsidian vault → /obsidian (shared knowledge base for all agents)
     const obsidianDir = path.join(hostDataDir, 'obsidian');
     fs.mkdirSync(obsidianDir, { recursive: true });
+    // Ensure agents learning directory exists for journal_reflect
+    fs.mkdirSync(path.join(obsidianDir, 'Consciousness', 'agents'), { recursive: true });
     binds.push(`${obsidianDir}:/obsidian:rw`);
 
     // Volume: ARCHITECTURE.md → /workspace/ARCHITECTURE.md (system knowledge for all agents)

--- a/src/agent-manager.ts
+++ b/src/agent-manager.ts
@@ -1039,6 +1039,31 @@ export class AgentManager {
       ? fs.readFileSync(claudeMdPath, 'utf8')
       : '';
 
+    // ── Constitution + Shards assembly ──────────────────────────────────────
+    // Read global constitution from hub mount
+    const hubDir = '/tmp/hub'; // hub is mounted as :ro
+    const constitutionPath = path.join(hubDir, 'constitution.md');
+    let policyPrefix = '';
+    if (fs.existsSync(constitutionPath)) {
+      policyPrefix = fs.readFileSync(constitutionPath, 'utf8') + '\n\n';
+    }
+
+    // Read shards referenced in manifest
+    const shards = agent.manifest.shards ?? [];
+    for (const shard of shards) {
+      const shardPath = path.join(hubDir, 'shards', `${shard}.md`);
+      if (fs.existsSync(shardPath)) {
+        policyPrefix += fs.readFileSync(shardPath, 'utf8') + '\n\n';
+      } else {
+        logger.warn({ agentId, shard }, 'Shard file not found — skipping');
+      }
+    }
+
+    // Prepend policy to CLAUDE.md content (constitution > shards > CLAUDE.md)
+    if (policyPrefix) {
+      claudeMdContent = policyPrefix + claudeMdContent;
+    }
+
     // Resolve team config from config.json (set during team install)
     let repoUrl = process.env.REPO_URL ?? '';
     let githubToken = process.env.GH_TOKEN ?? process.env.GITHUB_TOKEN ?? '';

--- a/src/agent-manager.ts
+++ b/src/agent-manager.ts
@@ -37,6 +37,7 @@ import { codec, ensureConsumer } from './nats-client.js';
 import { WorkflowDispatcher } from './workflow-dispatcher.js';
 import type { AlarmClock } from './alarm-clock.js';
 import { emitActivity } from './activity-emitter.js';
+import type { SecretManager } from './secret-manager.js';
 
 interface ObservabilityConfig {
   level?: string;
@@ -120,6 +121,7 @@ export class AgentManager {
     private readonly nc: NatsConnection,
     private readonly configService?: ConfigService,
     alarmClock?: AlarmClock,
+    private readonly secretManager?: SecretManager,
   ) {
     // Default: connects via /var/run/docker.sock on Linux
     this.docker = new Dockerode();
@@ -1256,6 +1258,15 @@ export class AgentManager {
       logger.debug({ agentId, projectRoot }, 'Mounting project workspace');
     } else if (agent.manifest.project_workspace && agent.manifest.repo_path) {
       logger.warn({ agentId }, 'project_workspace ignored: repo_path already set for /workspace/repo');
+    }
+
+    // ── Secret injection (deterministic agents only) ────────────────────────
+    if (this.secretManager) {
+      const resolved = this.secretManager.resolve(agent.manifest, isDeterministic);
+      env.push(...resolved.envVars);
+      for (const fm of resolved.fileMounts) {
+        binds.push(`${fm.hostPath}:${fm.containerPath}:ro`);
+      }
     }
 
     // Use per-agent image if specified in manifest.

--- a/src/agent-manager.ts
+++ b/src/agent-manager.ts
@@ -31,9 +31,9 @@ import {
 } from './config.js';
 import { logger } from './logger.js';
 import type { LoadedAgent, DispatchConfig } from './agent-registry.js';
-import { resolveTopicsForAgent, getInstanceId } from './agent-registry.js';
+import { resolveTopicsForAgent, getInstanceId, loadManifest, findBindingForAgent } from './agent-registry.js';
 import type { ConfigService, NanoConfig } from './config-service.js';
-import { codec } from './nats-client.js';
+import { codec, ensureConsumer } from './nats-client.js';
 import { WorkflowDispatcher } from './workflow-dispatcher.js';
 import type { AlarmClock } from './alarm-clock.js';
 import { emitActivity } from './activity-emitter.js';
@@ -844,6 +844,34 @@ export class AgentManager {
     });
 
     await this.startAgent(agent);
+  }
+
+  /**
+   * Hot-reload an agent: re-read manifest from disk, recreate JetStream consumer,
+   * and restart the container with fresh env vars derived from the new manifest.
+   */
+  async reloadAgent(agentId: string): Promise<void> {
+    const state = this.states.get(agentId);
+    if (!state) {
+      throw new Error(`Agent '${agentId}' not found`);
+    }
+
+    const agentDir = path.join(DATA_DIR, 'agents', agentId);
+    const manifest = loadManifest(agentDir);
+    const binding = findBindingForAgent(agentId, path.join(DATA_DIR, 'teams'));
+    const topics = resolveTopicsForAgent(manifest, binding);
+
+    // Update in-memory agent definition
+    const updatedAgent: LoadedAgent = { manifest, dir: agentDir, binding };
+    state.agent = updatedAgent;
+
+    // Recreate JetStream consumer with (potentially changed) filter subjects
+    await ensureConsumer(this.nc, 'AGENTS', manifest.id, topics);
+
+    // Restart container so it picks up new env vars from updated manifest
+    await this.restartAgent(agentId);
+
+    logger.info({ agentId, topics }, 'Agent hot-reloaded from disk');
   }
 
   /**

--- a/src/agent-manager.ts
+++ b/src/agent-manager.ts
@@ -166,8 +166,15 @@ export class AgentManager {
       // Read current token from credentials.json so SDK doesn't refuse to start.
       const credPath = path.join(DATA_DIR, 'credentials.json');
       try {
-        const creds = JSON.parse(fs.readFileSync(credPath, 'utf8')) as { oauth_token?: string };
-        if (creds.oauth_token) vars.push(`CLAUDE_CODE_OAUTH_TOKEN=${creds.oauth_token}`);
+        const creds = JSON.parse(fs.readFileSync(credPath, 'utf8')) as {
+          oauth_token?: string;
+          anthropic?: { apiKey?: string };
+        };
+        if (creds.oauth_token) {
+          vars.push(`CLAUDE_CODE_OAUTH_TOKEN=${creds.oauth_token}`);
+        } else if (creds.anthropic?.apiKey) {
+          vars.push(`ANTHROPIC_API_KEY=${creds.anthropic.apiKey}`);
+        }
       } catch { /* ignore */ }
       return vars;
     }
@@ -391,6 +398,13 @@ export class AgentManager {
 
   getAgent(agentId: string): LoadedAgent | undefined {
     return this.states.get(agentId)?.agent;
+  }
+
+  getAllAgents(): Array<LoadedAgent & { status: string }> {
+    return Array.from(this.states.values()).map(s => ({
+      ...s.agent,
+      status: s.status,
+    }));
   }
 
   /**

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -95,6 +95,10 @@ export interface AgentManifest {
   handler?: string;
   /** Mount host Obsidian vault at /obsidian in container. Requires HOST_OBSIDIAN_VAULT_PATH env var. */
   obsidian_mount?: boolean;
+  /** Secret keys to inject as env vars (deterministic agents only). */
+  required_env?: string[];
+  /** Secrets to mount as files (deterministic agents only). */
+  required_files?: Array<{ secret: string; path: string; mode?: string }>;
 }
 
 /** Resolve named outputs to { portName: natsSubject } map */

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -95,6 +95,8 @@ export interface AgentManifest {
   handler?: string;
   /** Mount host Obsidian vault at /obsidian in container. Requires HOST_OBSIDIAN_VAULT_PATH env var. */
   obsidian_mount?: boolean;
+  /** Policy shards to include in system prompt. References files in hub/shards/{name}.md */
+  shards?: string[];
   /** Secret keys to inject as env vars (deterministic agents only). */
   required_env?: string[];
   /** Secrets to mount as files (deterministic agents only). */

--- a/src/api-server.ts
+++ b/src/api-server.ts
@@ -303,7 +303,7 @@ export async function createApiApp(
   manager: AgentManager,
   nc: NatsConnection,
   configService: ConfigService,
-  opts: { setupMode: SetupMode; mcpManager?: McpManager; mcpGateway?: McpGateway; ticketRegistry?: TicketRegistry; workspaceProvider?: WorkspaceProvider },
+  opts: { setupMode: SetupMode; mcpManager?: McpManager; mcpGateway?: McpGateway; ticketRegistry?: TicketRegistry; workspaceProvider?: WorkspaceProvider; secretManager?: import('./secret-manager.js').SecretManager },
 ): Promise<express.Application> {
   const app = express();
   app.use(express.json());
@@ -948,6 +948,37 @@ export async function createApiApp(
     res.json({ agents, edges });
   });
 
+  // ── Secrets API ─────────────────────────────────────────────────────────────
+  if (opts.secretManager) {
+    const sm = opts.secretManager;
+
+    app.get('/api/secrets', (_req: Request, res: Response) => {
+      const keys = sm.listKeys();
+      const agents = manager.getAllAgents();
+      const required: Record<string, string[]> = {};
+      for (const a of agents) {
+        const reqs = (a.manifest as unknown as Record<string, unknown>).required_env as string[] | undefined ?? [];
+        if (reqs.length > 0) required[a.manifest.id] = reqs;
+      }
+      res.json({
+        secrets: keys.map(k => ({ key: k, set: true })),
+        required,
+      });
+    });
+
+    app.post('/api/secrets', (req: Request, res: Response) => {
+      const { key, value } = req.body ?? {};
+      if (!key || !value) return res.status(400).json({ error: 'key and value required' });
+      sm.set(key, value);
+      res.json({ ok: true, key });
+    });
+
+    app.delete('/api/secrets/:key', (req: Request, res: Response) => {
+      sm.delete(req.params.key);
+      res.json({ ok: true });
+    });
+  }
+
   // ── Chat with any agent (NATS bridge) ──────────────────────────────────────
   // Default: consciousness (user.message.inbound)
   // With ?agent=foreman: agent.foreman.inbox
@@ -1373,7 +1404,7 @@ export async function startApiServer(
   manager: AgentManager,
   nc: NatsConnection,
   configService: ConfigService,
-  opts: { setupMode: SetupMode; mcpManager?: McpManager; mcpGateway?: McpGateway; ticketRegistry?: TicketRegistry; workspaceProvider?: WorkspaceProvider },
+  opts: { setupMode: SetupMode; mcpManager?: McpManager; mcpGateway?: McpGateway; ticketRegistry?: TicketRegistry; workspaceProvider?: WorkspaceProvider; secretManager?: import('./secret-manager.js').SecretManager },
 ): Promise<http.Server> {
   const app = await createApiApp(manager, nc, configService, opts);
 

--- a/src/api-server.ts
+++ b/src/api-server.ts
@@ -974,7 +974,9 @@ export async function createApiApp(
     });
 
     app.delete('/api/secrets/:key', (req: Request, res: Response) => {
-      sm.delete(req.params.key);
+      const key = req.params.key;
+      if (!/^[a-zA-Z0-9_-]+$/.test(key)) return res.status(400).json({ error: 'Invalid key' });
+      sm.delete(key);
       res.json({ ok: true });
     });
   }
@@ -991,14 +993,19 @@ export async function createApiApp(
     }, null, 2));
   }
 
+  const SAFE_THREAD_ID = /^[a-zA-Z0-9_-]+$/;
+
   function loadThread(id: string) {
+    if (!SAFE_THREAD_ID.test(id)) return null;
     const p = path.join(CHAT_DIR, `${id}.json`);
     if (!fs.existsSync(p)) return null;
     return JSON.parse(fs.readFileSync(p, 'utf8'));
   }
 
   function saveThread(thread: Record<string, unknown>) {
-    fs.writeFileSync(path.join(CHAT_DIR, `${thread.id}.json`), JSON.stringify(thread, null, 2));
+    const id = thread.id as string;
+    if (!SAFE_THREAD_ID.test(id)) throw new Error('Invalid thread ID');
+    fs.writeFileSync(path.join(CHAT_DIR, `${id}.json`), JSON.stringify(thread, null, 2));
   }
 
   // List threads
@@ -1032,7 +1039,7 @@ export async function createApiApp(
     saveThread(thread);
 
     // Send to chat-agent via NATS and collect response
-    const replySubject = `chat.thread.reply.${Date.now()}`;
+    const replySubject = `chat.thread.reply.${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     const sub = nc.subscribe(replySubject, { max: 1, timeout: 60000 });
 
     await publish(nc, 'agent.chat-agent.inbox', JSON.stringify({
@@ -1067,6 +1074,7 @@ export async function createApiApp(
   // ── Per-agent activity SSE stream ─────────────────────────────────────────
   app.get('/api/agents/:agentId/stream', (req: Request, res: Response) => {
     const { agentId } = req.params;
+    if (!isValidAgentId(agentId)) return res.status(400).json({ error: 'Invalid agent ID' });
     res.writeHead(200, {
       'Content-Type': 'text/event-stream',
       'Cache-Control': 'no-cache',

--- a/src/api-server.ts
+++ b/src/api-server.ts
@@ -663,6 +663,30 @@ export async function createApiApp(
     }
   });
 
+  // ── Hot-reload: re-read manifest + recreate consumer + restart container ──
+
+  app.post('/api/agents/:agentId/reload', async (req: Request, res: Response) => {
+    try {
+      const agentId = req.params.agentId;
+      if (!isValidAgentId(agentId)) return res.status(400).json({ error: 'Invalid agent ID' });
+
+      const agent = manager.getAgent(agentId);
+      if (!agent) return res.status(404).json({ error: 'Agent not found' });
+
+      const lastRestart = restartCooldowns.get(agentId) ?? 0;
+      if (Date.now() - lastRestart < RESTART_COOLDOWN_MS) {
+        return res.status(429).json({ error: 'Reload cooldown active, please wait' });
+      }
+      restartCooldowns.set(agentId, Date.now());
+
+      await manager.reloadAgent(agentId);
+      res.json({ ok: true });
+    } catch (err) {
+      logger.error({ err }, 'POST /api/agents/:agentId/reload error');
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  });
+
   // ── Phase 5: Zero-downtime deploy ─────────────────────────────────────────
 
   app.post('/api/agents/:agentId/deploy', async (req: Request, res: Response) => {

--- a/src/api-server.ts
+++ b/src/api-server.ts
@@ -1064,6 +1064,33 @@ export async function createApiApp(
     res.json(thread);
   });
 
+  // ── Per-agent activity SSE stream ─────────────────────────────────────────
+  app.get('/api/agents/:agentId/stream', (req: Request, res: Response) => {
+    const { agentId } = req.params;
+    res.writeHead(200, {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      'Connection': 'keep-alive',
+    });
+    res.write(':\n\n');
+
+    const sub = nc.subscribe(`activity.${agentId}`);
+    const actCodec = StringCodec();
+
+    (async () => {
+      for await (const msg of sub) {
+        try {
+          const data = actCodec.decode(msg.data);
+          res.write(`data: ${data}\n\n`);
+        } catch { /* connection closed */ }
+      }
+    })();
+
+    req.on('close', () => {
+      sub.unsubscribe();
+    });
+  });
+
   // ── Chat with any agent (NATS bridge) ──────────────────────────────────────
   // Default: consciousness (user.message.inbound)
   // With ?agent=foreman: agent.foreman.inbox

--- a/src/api-server.ts
+++ b/src/api-server.ts
@@ -979,6 +979,91 @@ export async function createApiApp(
     });
   }
 
+  // ── Chat Threads API ────────────────────────────────────────────────────────
+  const CHAT_DIR = path.join(DATA_DIR, 'chat', 'threads');
+  fs.mkdirSync(CHAT_DIR, { recursive: true });
+
+  // Ensure main thread exists
+  const mainThreadPath = path.join(CHAT_DIR, 'main.json');
+  if (!fs.existsSync(mainThreadPath)) {
+    fs.writeFileSync(mainThreadPath, JSON.stringify({
+      id: 'main', title: 'General', messages: [], pending: false, createdAt: Date.now()
+    }, null, 2));
+  }
+
+  function loadThread(id: string) {
+    const p = path.join(CHAT_DIR, `${id}.json`);
+    if (!fs.existsSync(p)) return null;
+    return JSON.parse(fs.readFileSync(p, 'utf8'));
+  }
+
+  function saveThread(thread: Record<string, unknown>) {
+    fs.writeFileSync(path.join(CHAT_DIR, `${thread.id}.json`), JSON.stringify(thread, null, 2));
+  }
+
+  // List threads
+  app.get('/api/chat/threads', (_req: Request, res: Response) => {
+    const files = fs.readdirSync(CHAT_DIR).filter(f => f.endsWith('.json'));
+    const threads = files.map(f => {
+      const t = JSON.parse(fs.readFileSync(path.join(CHAT_DIR, f), 'utf8'));
+      const msgs = t.messages ?? [];
+      const last = msgs.length > 0 ? msgs[msgs.length - 1] : null;
+      return { id: t.id, title: t.title, pending: t.pending ?? false, lastMessage: last, messageCount: msgs.length };
+    });
+    res.json(threads);
+  });
+
+  // Get thread messages
+  app.get('/api/chat/threads/:id/messages', (req: Request, res: Response) => {
+    const thread = loadThread(req.params.id);
+    if (!thread) return res.status(404).json({ error: 'Thread not found' });
+    res.json(thread.messages ?? []);
+  });
+
+  // Send message to thread (proxies to chat-agent via NATS)
+  app.post('/api/chat/threads/:id/messages', async (req: Request, res: Response) => {
+    const { text } = req.body ?? {};
+    if (!text) return res.status(400).json({ error: 'text required' });
+    const thread = loadThread(req.params.id);
+    if (!thread) return res.status(404).json({ error: 'Thread not found' });
+
+    // Append user message
+    thread.messages.push({ role: 'user', text, ts: Date.now() });
+    saveThread(thread);
+
+    // Send to chat-agent via NATS and collect response
+    const replySubject = `chat.thread.reply.${Date.now()}`;
+    const sub = nc.subscribe(replySubject, { max: 1, timeout: 60000 });
+
+    await publish(nc, 'agent.chat-agent.inbox', JSON.stringify({
+      text,
+      replySubject,
+      threadId: thread.id,
+    }));
+
+    try {
+      for await (const msg of sub) {
+        const reply = JSON.parse(codec.decode(msg.data));
+        thread.messages.push({ role: 'agent', text: reply.result ?? '', agentId: 'chat-agent', ts: Date.now() });
+        if (thread.pending) thread.pending = false;
+        saveThread(thread);
+        res.json({ ok: true, reply: reply.result });
+        return;
+      }
+    } catch {
+      res.json({ ok: true, reply: '(waiting for response)' });
+    }
+  });
+
+  // Create new thread
+  app.post('/api/chat/threads', (req: Request, res: Response) => {
+    const { title } = req.body ?? {};
+    const id = `thread-${Date.now()}`;
+    const thread = { id, title: title ?? 'New Thread', messages: [], pending: false, createdAt: Date.now() };
+    saveThread(thread);
+    res.json(thread);
+  });
+
   // ── Chat with any agent (NATS bridge) ──────────────────────────────────────
   // Default: consciousness (user.message.inbound)
   // With ?agent=foreman: agent.foreman.inbox

--- a/src/api-server.ts
+++ b/src/api-server.ts
@@ -1040,7 +1040,7 @@ export async function createApiApp(
 
     // Send to chat-agent via NATS and collect response
     const replySubject = `chat.thread.reply.${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-    const sub = nc.subscribe(replySubject, { max: 1, timeout: 60000 });
+    const sub = nc.subscribe(replySubject, { max: 1 });
 
     await publish(nc, 'agent.chat-agent.inbox', JSON.stringify({
       text,
@@ -1048,17 +1048,27 @@ export async function createApiApp(
       threadId: thread.id,
     }));
 
-    try {
+    // Wait for reply with 60s timeout
+    const timeout = new Promise<null>((resolve) => setTimeout(() => resolve(null), 60_000));
+    const replyPromise = (async () => {
       for await (const msg of sub) {
-        const reply = JSON.parse(codec.decode(msg.data));
-        thread.messages.push({ role: 'agent', text: reply.result ?? '', agentId: 'chat-agent', ts: Date.now() });
-        if (thread.pending) thread.pending = false;
-        saveThread(thread);
-        res.json({ ok: true, reply: reply.result });
-        return;
+        return JSON.parse(codec.decode(msg.data));
       }
-    } catch {
-      res.json({ ok: true, reply: '(waiting for response)' });
+      return null;
+    })();
+
+    const reply = await Promise.race([replyPromise, timeout]) as Record<string, unknown> | null;
+    sub.unsubscribe();
+
+    if (reply) {
+      const replyText = (reply.result as string) ?? '';
+      thread.messages.push({ role: 'agent', text: replyText, agentId: 'chat-agent', ts: Date.now() });
+      if (thread.pending) (thread as Record<string, unknown>).pending = false;
+      saveThread(thread);
+      res.json({ ok: true, reply: replyText });
+    } else {
+      saveThread(thread);
+      res.json({ ok: true, reply: '(timeout — agent is processing)' });
     }
   });
 

--- a/src/api-server.ts
+++ b/src/api-server.ts
@@ -886,6 +886,44 @@ export async function createApiApp(
     });
   });
 
+  // ── Agent topology (for graph visualization) ─────────────────────────────
+  app.get('/api/agents/topology', (_req: Request, res: Response) => {
+    const agents = manager.getAllAgents().map(a => ({
+      id: a.manifest.id,
+      name: a.manifest.name ?? a.manifest.id,
+      description: a.manifest.description ?? '',
+      icon: (a.manifest as unknown as Record<string, unknown>).icon as string ?? '',
+      status: a.status,
+      subscribe_topics: a.manifest.subscribe_topics ?? [],
+      outputs: (a.manifest.outputs ?? []).map((o: { port: string; subject?: string }) => ({
+        port: o.port,
+        subject: o.subject ?? '',
+      })),
+    }));
+
+    // Build edges: output.subject of agent A matches subscribe_topic of agent B
+    const edges: Array<{ from: string; to: string; subject: string; port: string }> = [];
+    for (const src of agents) {
+      for (const output of src.outputs) {
+        if (!output.subject) continue;
+        for (const dst of agents) {
+          if (dst.id === src.id) continue;
+          const matches = dst.subscribe_topics.some((topic: string) => {
+            // Exact match or wildcard match (agent.*.task matches agent.foreman.task)
+            if (topic === output.subject) return true;
+            const regex = new RegExp('^' + topic.replace(/\./g, '\\.').replace(/\*/g, '[^.]+').replace(/>/g, '.+') + '$');
+            return regex.test(output.subject);
+          });
+          if (matches) {
+            edges.push({ from: src.id, to: dst.id, subject: output.subject, port: output.port });
+          }
+        }
+      }
+    }
+
+    res.json({ agents, edges });
+  });
+
   // ── Chat with any agent (NATS bridge) ──────────────────────────────────────
   // Default: consciousness (user.message.inbound)
   // With ?agent=foreman: agent.foreman.inbox

--- a/src/index.ts
+++ b/src/index.ts
@@ -149,6 +149,14 @@ async function bootstrapBaseAgents(
     return [];
   }
 
+  // Copy ARCHITECTURE.md from hub to data dir so agent-manager can mount it into containers
+  const hubArchPath = path.join(HUB_CACHE_DIR, 'ARCHITECTURE.md');
+  const dataArchPath = path.join(dataDir, 'ARCHITECTURE.md');
+  if (fs.existsSync(hubArchPath)) {
+    fs.copyFileSync(hubArchPath, dataArchPath);
+    logger.debug('Copied ARCHITECTURE.md from hub to data dir');
+  }
+
   const agents: Array<{ manifest: ReturnType<typeof loadManifest>; dir: string }> = [];
   for (const agentId of BASE_AGENTS) {
     const agent = installAgentFromHub(dataDir, agentId);

--- a/src/index.ts
+++ b/src/index.ts
@@ -251,6 +251,14 @@ async function main(): Promise<void> {
   const mcpGateway = new McpGateway(
     ticketRegistry,
     (agentId) => {
+      // Hot-reload: re-read manifest from disk on each request for fresh permissions
+      try {
+        const manifestPath = path.join(DATA_DIR, 'agents', agentId, 'manifest.json');
+        if (fs.existsSync(manifestPath)) {
+          const fresh = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+          return fresh.mcp_permissions ?? {};
+        }
+      } catch { /* fallback to in-memory */ }
       const agent = manager.getAgent(agentId);
       return agent?.manifest.mcp_permissions ?? {};
     },
@@ -262,8 +270,23 @@ async function main(): Promise<void> {
     mcpServerRegistry,
     gatewayOpts,
     (agentId) => {
+      // Hot-reload: re-read manifest from disk for fresh output map
+      try {
+        const manifestPath = path.join(DATA_DIR, 'agents', agentId, 'manifest.json');
+        if (fs.existsSync(manifestPath)) {
+          const fresh = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+          return resolveOutputMap(fresh);
+        }
+      } catch { /* fallback to in-memory */ }
       const agent = manager.getAgent(agentId);
       return agent ? resolveOutputMap(agent.manifest) : {};
+    },
+    () => {
+      return manager.getAllAgents().map(a => ({
+        id: a.manifest.id,
+        status: a.status,
+        description: a.manifest.description ?? '',
+      }));
     },
   );
   mcpGateway.start(MCP_GATEWAY_PORT);

--- a/src/index.ts
+++ b/src/index.ts
@@ -371,15 +371,21 @@ async function main(): Promise<void> {
     }
   }
 
-  // ── Floating timer: wake consciousness after 30 min of global silence ──────
+  // ── Floating timer: wake consciousness after configurable silence ────────
   {
-    const SILENCE_TIMEOUT_MS = 30 * 60 * 1000;
+    const silenceMinutes = (() => {
+      try {
+        const cfg = JSON.parse(fs.readFileSync(path.join(DATA_DIR, 'config.json'), 'utf8'));
+        return cfg.silenceTimeoutMinutes ?? 30;
+      } catch { return 30; }
+    })();
+    const SILENCE_TIMEOUT_MS = silenceMinutes * 60 * 1000;
     let silenceTimer: ReturnType<typeof setTimeout> | null = null;
 
     function resetSilenceTimer() {
       if (silenceTimer) clearTimeout(silenceTimer);
       silenceTimer = setTimeout(async () => {
-        logger.info('Global silence 30 min — waking consciousness');
+        logger.info('Global silence %d min — waking consciousness', silenceMinutes);
         try {
           await publish(nc, 'soul.consciousness.inbox', JSON.stringify({
             type: 'reflection', reason: 'Global silence. Read insights, check goals.', ts: Date.now(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,7 @@ import { detectSetupMode, isSetupRequired } from './setup-detector.js';
 import { ConfigService } from './config-service.js';
 import { startEmbeddedNats, stopEmbeddedNats } from './nats-embedded.js';
 import { SecretStore } from './secret-store.js';
+import { SecretManager } from './secret-manager.js';
 import { McpServerRegistry } from './mcp-server-registry.js';
 import { McpManager } from './mcp-manager.js';
 import { WorkspaceProvider } from './workspace-provider.js';
@@ -200,10 +201,11 @@ async function main(): Promise<void> {
   const { AlarmClock } = await import('./alarm-clock.js');
   const alarmClock = new AlarmClock(nc, DATA_DIR);
 
-  const manager = new AgentManager(nc, configService, alarmClock);
-
-  // ── Secret store + MCP server registry + MCP manager ────────────────────────
+  // ── Secret store + SecretManager + MCP server registry + MCP manager ────────
   const secretStore = new SecretStore();
+  const secretManager = new SecretManager(DATA_DIR);
+
+  const manager = new AgentManager(nc, configService, alarmClock, secretManager);
   const mcpServerRegistry = new McpServerRegistry();
   mcpServerRegistry.load();
   const mcpManager = new McpManager(secretStore);

--- a/src/index.ts
+++ b/src/index.ts
@@ -407,7 +407,7 @@ async function main(): Promise<void> {
 
   // ── 6. Start API server ─────────────────────────────────────────────────────
   // Settings feature is always loaded inside startApiServer
-  const httpServer = await startApiServer(manager, nc, configService, { setupMode, mcpManager, mcpGateway, ticketRegistry, workspaceProvider });
+  const httpServer = await startApiServer(manager, nc, configService, { setupMode, mcpManager, mcpGateway, ticketRegistry, workspaceProvider, secretManager });
 
   // ── 6b. Post-restart deploy verification ──────────────────────────────────
   const pendingDeployPath = path.join(DATA_DIR, 'pending-deploy.json');

--- a/src/mcp-gateway.ts
+++ b/src/mcp-gateway.ts
@@ -290,6 +290,7 @@ function buildMcpServer(
   permissions: PermissionMap,
   opts?: GatewayOptions,
   agentOutputs?: Record<string, string>,
+  listAgentsFn?: () => import('./soul-mcp.js').AgentInfo[],
 ): McpServer {
   const server = new McpServer({ name: 'nano-agent-mcp-gateway', version: '1.0.0' });
 
@@ -912,7 +913,7 @@ function buildMcpServer(
   // ── Built-in: soul (consciousness layer tools) ─────────────────────────────
 
   if (opts && opts.nc && permissions['soul'] !== undefined) {
-    registerSoulTools(server, opts.nc, opts.dataDir, agentId, permissions['soul'] as string[], agentOutputs);
+    registerSoulTools(server, opts.nc, opts.dataDir, agentId, permissions['soul'] as string[], agentOutputs, listAgentsFn);
   }
 
   return server;
@@ -935,6 +936,7 @@ export class McpGateway {
     private readonly mcpServerRegistry?: McpServerRegistry,
     private readonly gatewayOpts?: GatewayOptions,
     private readonly resolveAgentOutputs?: (agentId: string) => Record<string, string>,
+    private readonly listAgentsFn?: () => import('./soul-mcp.js').AgentInfo[],
   ) {}
 
   start(port: number): void {
@@ -996,7 +998,7 @@ export class McpGateway {
 
         // ── Built-in tools (tickets, etc.) via McpServer SDK ──────────────────
         const agentOutputs = this.resolveAgentOutputs?.(agentId) ?? {};
-        const server = buildMcpServer(this.ticketRegistry, agentId, permissions, this.gatewayOpts, agentOutputs);
+        const server = buildMcpServer(this.ticketRegistry, agentId, permissions, this.gatewayOpts, agentOutputs, this.listAgentsFn);
         const transport = new StreamableHTTPServerTransport({
           sessionIdGenerator: undefined, // stateless
         });
@@ -1224,6 +1226,8 @@ export class McpGateway {
         { name: 'evaluate_self', description: 'Trigger consciousness self-evaluation loop.', inputSchema: { type: 'object' as const, properties: {} } },
         { name: 'continue_dialogue', description: 'Continue dialogue with conscience — add counter-arguments to an idea.', inputSchema: { type: 'object' as const, required: ['ideaId', 'argument'], properties: { ideaId: { type: 'string' }, argument: { type: 'string' } } } },
         { name: 'publish_signal', description: 'Publish a signal to a named output declared in your manifest.', inputSchema: { type: 'object' as const, required: ['output', 'payload'], properties: { output: { type: 'string' }, payload: { type: 'string' } } } },
+        { name: 'dispatch_task', description: 'Send a task to any agent by ID. Publishes to agent.{agentId}.task.', inputSchema: { type: 'object' as const, required: ['targetAgent', 'payload'], properties: { targetAgent: { type: 'string' }, payload: { type: 'string' } } } },
+        { name: 'list_agents', description: 'List all currently registered agents and their status.', inputSchema: { type: 'object' as const, properties: {} } },
       ];
       const soulPerms = permissions['soul'];
       for (const tool of soulTools) {

--- a/src/nats-client.ts
+++ b/src/nats-client.ts
@@ -15,6 +15,7 @@
 
 import {
   AckPolicy,
+  DeliverPolicy,
   connect,
   headers as natsHeaders,
   NatsConnection,
@@ -112,6 +113,7 @@ export async function ensureConsumer(
   const config: Partial<ConsumerConfig> = {
     durable_name: consumerName,
     ack_policy: AckPolicy.Explicit,
+    deliver_policy: DeliverPolicy.New,
     max_deliver: 3,
     ack_wait: 600_000_000_000, // 10 min in nanoseconds (agents may run long tasks)
   };
@@ -123,23 +125,16 @@ export async function ensureConsumer(
     (config as Record<string, unknown>).filter_subjects = filterSubjects;
   }
 
-  // Check if an existing consumer has different filter subjects — JetStream cannot
-  // update filter_subject(s) in place, so we must delete and recreate.
-  let needsRecreate = false;
+  // Always delete and recreate consumer on startup to ensure:
+  // 1. Filter subjects are up to date (JetStream can't update in place)
+  // 2. deliver_policy: new takes effect (prevents replay of old messages)
   try {
-    const existing = await jsm.consumers.info(streamName, consumerName);
-    const existingFilters: string[] =
-      existing.config.filter_subjects ??
-      (existing.config.filter_subject ? [existing.config.filter_subject] : []);
-    const sorted = (a: string[]) => [...a].sort().join(',');
-    if (sorted(existingFilters) !== sorted(filterSubjects)) {
-      needsRecreate = true;
-      await jsm.consumers.delete(streamName, consumerName);
-      logger.debug({ agentId, old: existingFilters, new: filterSubjects }, 'Consumer filter changed — deleted for recreation');
-    }
+    await jsm.consumers.delete(streamName, consumerName);
+    logger.debug({ agentId }, 'Deleted existing consumer for clean recreation');
   } catch {
     // Consumer doesn't exist yet — will be created below
   }
+  const needsRecreate = true;
 
   try {
     await jsm.consumers.add(streamName, config as ConsumerConfig);

--- a/src/secret-manager.ts
+++ b/src/secret-manager.ts
@@ -1,0 +1,86 @@
+/**
+ * SecretManager — wraps SecretStore with file mount support and deterministic-only guard.
+ *
+ * LLM agents never receive secrets directly. Only deterministic agents
+ * (kind === 'deterministic') get secrets injected as env vars and/or file mounts.
+ *
+ * File mounts: secrets written to host temp files and bind-mounted into containers
+ * with restrictive permissions (default 0400).
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+import { SecretStore } from './secret-store.js';
+import { logger } from './logger.js';
+
+export interface FileMount {
+  secret: string;   // key in secret store
+  path: string;     // container path to mount to
+  mode?: string;    // file permission mode, default '0400'
+}
+
+export interface ResolvedSecrets {
+  envVars: string[];
+  fileMounts: Array<{ hostPath: string; containerPath: string; mode: string }>;
+}
+
+export class SecretManager {
+  private readonly store: SecretStore;
+  private readonly mountDir: string;
+
+  constructor(private readonly dataDir: string) {
+    this.store = new SecretStore();
+    this.mountDir = path.join(dataDir, 'secret-mounts');
+    fs.mkdirSync(this.mountDir, { recursive: true });
+  }
+
+  /** Resolve secrets for an agent. Returns empty for LLM agents. */
+  resolve(manifest: {
+    id: string;
+    required_env?: string[];
+    required_files?: FileMount[];
+  }, isDeterministic: boolean): ResolvedSecrets {
+    if (!isDeterministic) {
+      return { envVars: [], fileMounts: [] };
+    }
+
+    const envVars = this.store.getEnvVars(manifest.required_env ?? []);
+
+    const missingEnv = this.store.getMissing(manifest.required_env ?? []);
+    if (missingEnv.length > 0) {
+      logger.warn({ agentId: manifest.id, missing: missingEnv }, 'Agent missing required secrets');
+    }
+
+    const fileMounts: ResolvedSecrets['fileMounts'] = [];
+    for (const fm of manifest.required_files ?? []) {
+      const value = this.store.get(fm.secret);
+      if (!value) {
+        logger.warn({ agentId: manifest.id, secret: fm.secret }, 'File mount secret not found — skipping');
+        continue;
+      }
+      const hostPath = path.join(this.mountDir, `${manifest.id}-${fm.secret}`);
+      fs.writeFileSync(hostPath, value, { mode: parseInt(fm.mode ?? '0400', 8) });
+      fileMounts.push({
+        hostPath,
+        containerPath: fm.path,
+        mode: fm.mode ?? '0400',
+      });
+    }
+
+    logger.debug(
+      { agentId: manifest.id, envCount: envVars.length, fileCount: fileMounts.length },
+      'Secrets resolved for deterministic agent',
+    );
+
+    return { envVars, fileMounts };
+  }
+
+  // Delegate store methods for API use
+  get(key: string): string | undefined { return this.store.get(key); }
+  set(key: string, value: string): void { this.store.set(key, value); }
+  delete(key: string): void { this.store.delete(key); }
+  listKeys(): string[] { return this.store.listKeys(); }
+  getMissing(keys: string[]): string[] { return this.store.getMissing(keys); }
+  getEnvVars(keys: string[]): string[] { return this.store.getEnvVars(keys); }
+}

--- a/src/soul-mcp.ts
+++ b/src/soul-mcp.ts
@@ -103,6 +103,7 @@ export function registerSoulTools(
 ): void {
   const obsidianBase = path.join(dataDir, 'obsidian', 'Consciousness');
   const questionsBase = path.join(dataDir, 'questions');
+  let reflectCounter = 0;
 
   function allowed(toolName: string): boolean {
     if (permissions === '*') return true;
@@ -456,8 +457,9 @@ export function registerSoulTools(
         verdict_self: z.enum(['good', 'mixed', 'poor']).describe('Self-assessment of task performance'),
         category: z.enum(['scope', 'quality', 'communication', 'process', 'tooling']).nullable().describe('Learning category, or null if noop'),
         learning: z.string().nullable().describe('Specific actionable learning, or null if nothing new'),
+        task_summary: z.string().optional().describe('Brief description of the task that was completed'),
       },
-      async ({ verdict_self, category, learning }) => {
+      async ({ verdict_self, category, learning, task_summary }) => {
         try {
           const agentDir = path.join(obsidianBase, 'agents', agentId);
           fs.mkdirSync(agentDir, { recursive: true });
@@ -465,7 +467,7 @@ export function registerSoulTools(
           const timestamp = new Date().toISOString();
           const ticketId = process.env.EPHEMERAL_TICKET_ID ?? 'unknown';
           const taskResult = process.env.EPHEMERAL_TASK_RESULT ?? 'done';
-          const taskSummary = process.env.EPHEMERAL_TASK_SUMMARY ?? 'unknown';
+          const taskSummary = task_summary ?? process.env.EPHEMERAL_TASK_SUMMARY ?? 'unknown';
           const learningText = learning ?? 'null (noop)';
           const categoryText = category ?? 'null';
 
@@ -495,20 +497,13 @@ export function registerSoulTools(
           });
 
           // Track learning count — publish batch_ready when threshold reached
-          const counterPath = path.join(obsidianBase, 'agents', '.reflect_counter');
-          let count = 0;
-          try {
-            count = parseInt(fs.readFileSync(counterPath, 'utf-8').trim(), 10) || 0;
-          } catch { /* file doesn't exist yet */ }
-          count += 1;
-          fs.writeFileSync(counterPath, String(count), 'utf-8');
-
-          if (count >= 5) {
+          reflectCounter += 1;
+          if (reflectCounter >= 5) {
             await publish(nc, 'soul.reflect.batch_ready', JSON.stringify({
-              count,
+              count: reflectCounter,
               timestamp,
             }));
-            fs.writeFileSync(counterPath, '0', 'utf-8');
+            reflectCounter = 0;
           }
 
           return textResult({ ok: true, verdict_self, category, learning: !!learning });

--- a/src/soul-mcp.ts
+++ b/src/soul-mcp.ts
@@ -446,6 +446,79 @@ export function registerSoulTools(
     );
   }
 
+  // ── journal_reflect ───────────────────────────────────────────────────────
+
+  if (allowed('journal_reflect')) {
+    server.tool(
+      'journal_reflect',
+      'Record self-reflection after completing a task. Appends learning to your agent profile in Obsidian.',
+      {
+        verdict_self: z.enum(['good', 'mixed', 'poor']).describe('Self-assessment of task performance'),
+        category: z.enum(['scope', 'quality', 'communication', 'process', 'tooling']).nullable().describe('Learning category, or null if noop'),
+        learning: z.string().nullable().describe('Specific actionable learning, or null if nothing new'),
+      },
+      async ({ verdict_self, category, learning }) => {
+        try {
+          const agentDir = path.join(obsidianBase, 'agents', agentId);
+          fs.mkdirSync(agentDir, { recursive: true });
+
+          const timestamp = new Date().toISOString();
+          const ticketId = process.env.EPHEMERAL_TICKET_ID ?? 'unknown';
+          const taskResult = process.env.EPHEMERAL_TASK_RESULT ?? 'done';
+          const taskSummary = process.env.EPHEMERAL_TASK_SUMMARY ?? 'unknown';
+          const learningText = learning ?? 'null (noop)';
+          const categoryText = category ?? 'null';
+
+          const entry = [
+            `\n## ${timestamp} — ${ticketId} (${taskResult})`,
+            '',
+            `- **verdict_self:** ${verdict_self}`,
+            `- **category:** ${categoryText}`,
+            `- **task:** ${taskSummary}`,
+            `- **learning:** ${learningText}`,
+            '',
+            '---',
+            '',
+          ].join('\n');
+
+          const learningsPath = path.join(agentDir, 'learnings.md');
+          fs.appendFileSync(learningsPath, entry, 'utf-8');
+
+          // Emit activity for dashboard
+          emitActivity(nc, {
+            agent: agentId,
+            type: 'reflect',
+            summary: learning
+              ? `Reflect (${verdict_self}/${category}): ${learning.slice(0, 120)}`
+              : `Reflect (${verdict_self}): noop`,
+            timestamp: Date.now(),
+          });
+
+          // Track learning count — publish batch_ready when threshold reached
+          const counterPath = path.join(obsidianBase, 'agents', '.reflect_counter');
+          let count = 0;
+          try {
+            count = parseInt(fs.readFileSync(counterPath, 'utf-8').trim(), 10) || 0;
+          } catch { /* file doesn't exist yet */ }
+          count += 1;
+          fs.writeFileSync(counterPath, String(count), 'utf-8');
+
+          if (count >= 5) {
+            await publish(nc, 'soul.reflect.batch_ready', JSON.stringify({
+              count,
+              timestamp,
+            }));
+            fs.writeFileSync(counterPath, '0', 'utf-8');
+          }
+
+          return textResult({ ok: true, verdict_self, category, learning: !!learning });
+        } catch (err: unknown) {
+          return errorResult((err as Error).message);
+        }
+      },
+    );
+  }
+
   // ── evaluate_self ────────────────────────────────────────────────────────────
 
   if (allowed('evaluate_self')) {

--- a/src/soul-mcp.ts
+++ b/src/soul-mcp.ts
@@ -1,8 +1,9 @@
 /**
  * Soul MCP Tools — atomic Obsidian file write + NATS kick for each tool.
  *
- * 8 tools: create_goal, create_idea, update_idea, create_plan,
- *          ask_user, answer_question, send_to_consciousness, journal_log
+ * 10 tools: create_goal, create_idea, update_idea, create_plan,
+ *           ask_user, answer_question, send_to_consciousness, journal_log,
+ *           dispatch_task, list_agents
  *
  * Each tool validates IDs, writes atomically (tmp + rename), and publishes
  * a NATS kick where applicable.
@@ -84,6 +85,13 @@ function errorResult(msg: string) {
  * @param agentId   ID of the calling agent (used as "from" in ask_user).
  * @param permissions Array of allowed tool names (e.g. ["create_goal","create_idea"]).
  */
+/** Agent info returned by listAgents callback */
+export interface AgentInfo {
+  id: string;
+  status: string;
+  description?: string;
+}
+
 export function registerSoulTools(
   server: McpServer,
   nc: NatsConnection,
@@ -91,6 +99,7 @@ export function registerSoulTools(
   agentId: string,
   permissions: string[] | '*',
   agentOutputs?: Record<string, string>,
+  listAgents?: () => AgentInfo[],
 ): void {
   const obsidianBase = path.join(dataDir, 'obsidian', 'Consciousness');
   const questionsBase = path.join(dataDir, 'questions');
@@ -496,6 +505,37 @@ export function registerSoulTools(
       });
 
       return { content: [{ type: 'text', text: `Dialogue continued on idea ${ideaId}, turn ${turnNum}.` }] };
+    });
+  }
+
+  // ── dispatch_task ───────────────────────────────────────────────────────────
+
+  if (allowed('dispatch_task')) {
+    server.tool('dispatch_task', 'Send a task to any agent by ID. Publishes to agent.{agentId}.inbox.', {
+      targetAgent: z.string().regex(SAFE_ID).describe('Agent ID to send the task to'),
+      payload: z.string().describe('JSON payload describing the task'),
+    }, async ({ targetAgent, payload }) => {
+      try { JSON.parse(payload); } catch { return errorResult('payload must be valid JSON'); }
+
+      const subject = `agent.${targetAgent}.inbox`;
+      await publish(nc, subject, payload);
+      emitActivity(nc, {
+        agent: agentId, type: 'action',
+        summary: `Dispatched task to ${targetAgent}`, timestamp: Date.now(),
+      });
+      return textResult({ ok: true, targetAgent, subject });
+    });
+  }
+
+  // ── list_agents ─────────────────────────────────────────────────────────────
+
+  if (allowed('list_agents')) {
+    server.tool('list_agents', 'List all currently registered agents and their status.', {}, async () => {
+      if (!listAgents) {
+        return errorResult('list_agents not available in this context');
+      }
+      const agents = listAgents();
+      return textResult({ agents });
     });
   }
 }

--- a/src/soul-mcp.ts
+++ b/src/soul-mcp.ts
@@ -324,6 +324,24 @@ export function registerSoulTools(
             agent: agentId, type: 'user', summary: 'Question asked',
             from: agentId, to: 'user', subtype: 'question', timestamp: Date.now(),
           });
+
+          // Create a chat thread for this question
+          const threadDir = path.join(dataDir, 'chat', 'threads');
+          try {
+            fs.mkdirSync(threadDir, { recursive: true });
+            const threadId = `ask-${questionId}`;
+            const threadPath = path.join(threadDir, `${threadId}.json`);
+            const thread = {
+              id: threadId,
+              title: question.substring(0, 50),
+              messages: [{ role: 'agent', text: question, agentId, ts: Date.now() }],
+              pending: true,
+              questionId,
+              createdAt: Date.now(),
+            };
+            fs.writeFileSync(threadPath, JSON.stringify(thread, null, 2));
+          } catch { /* ignore thread creation failure */ }
+
           return textResult({ questionId, status: 'pending' });
         } catch (err: unknown) {
           return errorResult((err as Error).message);

--- a/src/soul-mcp.ts
+++ b/src/soul-mcp.ts
@@ -535,6 +535,13 @@ export function registerSoulTools(
     }, async ({ targetAgent, payload }) => {
       try { JSON.parse(payload); } catch { return errorResult('payload must be valid JSON'); }
 
+      if (listAgents) {
+        const agents = listAgents();
+        if (!agents.some(a => a.id === targetAgent)) {
+          return errorResult(`Agent "${targetAgent}" not found. Available: ${agents.map(a => a.id).join(', ')}`);
+        }
+      }
+
       const subject = `agent.${targetAgent}.inbox`;
       await publish(nc, subject, payload);
       emitActivity(nc, {


### PR DESCRIPTION
## Summary

- **Constitution + Shards**: Three-layer policy hierarchy (constitution > shards > CLAUDE.md) assembled at container startup
- **Self-Reflect**: Agents self-reflect after every task via `journal_reflect` MCP tool, writing learnings to Obsidian
- **Consciousness Distill Loop**: Consciousness periodically reads per-agent learnings, distills patterns into profiles, creates ideas for systemic issues

## Changes

- `AgentManifest.shards` field for policy shard references
- `agent-manager.ts`: constitution + shards prepended to system prompt (with path traversal validation)
- `soul-mcp.ts`: new `journal_reflect` tool with in-memory batch counter
- `agent-runner/index.ts`: reflect phase after task completion (success AND rejection), Promise.race timeout, journal_reflect injected into allowedTools
- `activity-emitter.ts`: 'reflect' event type
- Obsidian `agents/` directory auto-creation

## Spec

`docs/superpowers/specs/2026-03-28-guidance-trust-learning-loop-design.md`

## Test plan

- [x] TypeScript build passes (nano-agent-team + agent-runner)
- [x] Code review — all CRITICAL and HIGH issues resolved
- [ ] Runtime test: rebuild stack, send ticket, verify learnings.md written

🤖 Generated with [Claude Code](https://claude.com/claude-code)